### PR TITLE
Xmlparser

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -18,21 +18,13 @@ odML (open metadata Markup Language)
 odML (open metadata Markup Language) is an XML based file format, 
 proposed by [Grewe et al. (2011) Front Neuroinform 5:16], in order 
 to provide metadata in an organized, human- and machine-readable way. 
-We illustrate the conceptual design of an odML metadata structure and 
-offer templates to facilitate the usage of odML in different laboratories 
-and experimental contexts. In addition, we demonstrate the advantages of 
-using odML to screen large numbers of data sets according to selection 
-criteria relevant for subsequent analyses. Well organized metadata 
-management is a key component to guarantee reproducibility of experiments 
-and to track provenance of performed analyses.
-
-<<<<<<< HEAD
-odML (open metadata Markup Language) helps to collect, store and share
-metadata. It is an open, flexible, easy-to-use, machine-, but also 
-human-readable format based on XML, developed in the German 
-Neuroinformatics Node (G-Node) of the International Neuroinformatics 
-Coordinating Facility (INCF) in Munich. odML connects 
-electrophysiological recorded data to the corresponding metadata.
+In this tutorial we will illustrate the conceptual design of odML and 
+show handson how you can generate your own odML metadata collection. 
+In addition, we demonstrate the advantages of using odML to screen 
+large numbers of data sets according to selection criteria relevant for 
+subsequent analyses. Well organized metadata management is a key 
+component to guarantee reproducibility of experiments and to track 
+provenance of performed analyses.
 
 What are metadata and why are they needed?
 	Metadata are data about data, and describing the conditions under 
@@ -45,7 +37,8 @@ What are metadata and why are they needed?
 
 	While maintaining their relation to the actual raw-data, odML can 
 	help to collect all metadata which are usually distributed over 
-	several files and formats, store and share them.
+	several files and formats, and to store them unitetly which 
+	facilitates sharing data and metadata.
 
 Key features of odML
 	- open, XML based language, to collect, store and share metadata
@@ -60,24 +53,30 @@ Structure of this tutorial
 
 The scientific background of the possible user community of odML varies 
 enormously (e.g. physics, informatics, mathematics, biology, medicine,
-psychology). Some users will be trained programmers, others probably have
-never learned a programming language. 
+psychology). Some users will be trained programmers, others probably 
+have never learned a programming language. 
 
 To cover the different demands of all users, we first provide a slow 
-introduction to odML that allows programming beginners to learn the basic 
-concepts behind odML. We will first examine a simple odML file using the 
-interactive odML-Editor. In a next step, we will demonstrat how to generate 
-the same odML file via the Python-odml library. In later chapters we present 
-more advanced possibilies of the Python-odML library (e.g. how to search for
-a certain metadata within an odML file). At the end, we will provide a few
-examples on how you can construct an odML depending on different use case 
-scenarios.
+introduction to odML that allows programming beginners to learn the 
+basic concepts behind odML. We will first examine a simple odML file 
+using the interactive odML-Editor. In a next step, we will demonstrate 
+how to generate the same odML file via the Python-odML library. In 
+later chapters we present more advanced possibilies of the Python-odML 
+library (e.g. how to search for a certain metadata within an odML file). 
 
-The set of example odML files, which we use within this tutorial are part of
-the documentation package (see example_odMLs folder). 
+Although the structure of an odML is depending on the needs of each 
+individual user, we would like to provide at the end of this tutorial a 
+few examples on how you can construct an odML assuming a set of use 
+case scenarios.
 
-Templates for general usable odML files can be downloaded (soon) from the 
-following website: $$$
+The set of example odML files, which we use within this tutorial are 
+part of the documentation package (see doc/example_odMLs/). 
+
+A set of odML templates are open accessible on the odML terminology 
+website "...". In the later chapters of this tutorial we will show you 
+how one can make use of these templates to generate your own specific 
+odML. 
+
 
 ------------------------------------------------------------------------
 

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -99,9 +99,10 @@ Debian/Ubuntu
 Introduction to odml
 ====================
 
-Before we start, it is important to know the basic structure of an odML file. 
-Within an odML file metadata are grouped and stored in a hierachical tree 
-structure which consists of four different odML objects.
+Before we start, it is important to know the basic structure of an odML 
+file. Within an odML file metadata are grouped and stored in a 
+hierachical tree structure which consists of four different odML 
+objects.
 
 - 'document':
 	- corresponds to the root of the tree (groups everything together)
@@ -120,50 +121,58 @@ structure which consists of four different odML objects.
 	- parent: property
 	- children: no children
 			
-Each of these odML objects has a certain set of attributes where the user
-can describe the object and its contents. Which attribute belongs to which
-object and the meaning of each attribute are better explained in an example
-odML file (e.g., "intro-example.odml").
+Each of these odML objects has a certain set of attributes where the 
+user can describe the object and its contents. Which attribute belongs 
+to which object and what is each attribute used for, is better explained 
+using an example odML file (e.g., "intro-example.odml").
 
 A first look with the odML-Editor
 ---------------------------------
-The best way to get familiar how the different odML objects are linked to 
-a complete structure of an odML file, which attribute belongs to which object 
-and what each attribute means, is to open one of the example odML files 
-in the odML-Editor.
+The best way to get familiar with how the different odML objects are 
+linked to a complete tree structure of an odML file, which attribute 
+belongs to which object and what each attribute means, is to open one 
+of the example odML files in the odML-Editor.
 
-Open the odML-Editor and use the "open files" button in the menu bar (top
-of the editor window) to select and open the odML example file "intro-example.odml".
+The odML-Editor ('odml-gui') is based on and part of the python-odml 
+library. You can find it in the python-odml folder. If you are used to
+a file browser just open the directory and use double left klick on 
+odml-gui to open the odML-Editor. If you prefer using the command line 
+use the command 'python odml-gui' instead.
 
-You should then see that the editor window is subdivided into three parts.
+When you opened the odML-Editor use the "open files" button in the menu 
+bar (top of the editor window) to select and open the odML example file 
+"intro-example.odml".
+
+You should then see that the editor window is subdivided into three 
+parts:
 	
 - Sections window:
-	The part on the upper left displays a tree view starting from the top 
-	section level of the document.
+	The part on the upper left displays a tree view starting from the 
+	top section level of the document.
 	
 - Properties window:
-	If you select one section in the tree view, the part on the upper right 
-	will display a table containing the name, value and value attributes of 
-	each property (row) belonging to the selected section.
+	If you select one section in the tree view, the part on the upper 
+	right will display a table containing the name, value and value 
+	attributes of each property (row) belonging to the selected section.
 	
 - Attributes window:
-	The part on the bottom shows you the attributes of the current selected 
-	section or property or of the document. As header above the values of 
-	the attributes the path to the selected section or property is displayed 
-	in red starting from the document. 
+	The part on the bottom shows you the attributes of the current 
+	selected section, property or document. As header above the values 
+	of the attributes the path to the selected section or property is 
+	displayed in red starting from the document. 
 
-Below the attributes window the file path to the currently loaded odML file 
-is displayed ("file:///.../doc/example_odMLs/intro-example.odml").
+Below the attributes window the file path to the currently loaded odML 
+file is displayed ("file:///.../doc/example_odMLs/intro-example.odml").
 	
-A more detailed look at the different objects and their attributes of the 
-example odML file ("intro-example.odml") is given in subchapters for each
-odML object type (document, section, property, value).
+If you are up to a more detailed look at the different objects and their 
+attributes jump to the subchapters for each odML object (document, 
+section, property, value).
 
 A first look with Python
 ------------------------
 If you are already a little bit familiar with the concept behind an odML
-file and you can also have a first look at the example odML file "intro-example.odml"
-in Python.
+file and you can also have a first look at the same example odML file 
+("intro-example.odml") in Python.
 
 If you open a Python shell, first, import the odml package::
 
@@ -171,11 +180,13 @@ If you open a Python shell, first, import the odml package::
 	
 You can load an odML file with the following command lines::
 	
-	>>> odmlfile = odml.tools.xmlparser.load("/doc/example_odMLs/intro-example.odml")
+	>>> odmlfile = "/doc/example_odMLs/intro-example.odml"
+	>>> exodml1 = odml.tools.xmlparser.load(odmlfile)
 	
-How you can access the attributes of the different odML objects is described
-in more detail in the subchapters for each odML object type (document, 
-section, property, value).
+How you can access the different odML objects and their attributes and 
+how you can use the attributes is described in more detail in the 
+subchapters for each odML object type (document, section, property, 
+value).
 
 The document
 ------------

--- a/odml/tools/xmlparser.py
+++ b/odml/tools/xmlparser.py
@@ -82,6 +82,7 @@ class XMLWriter:
 
             if isinstance(val, list):
                 for v in val:
+                    if v is None: continue
                     ele = XMLWriter.save_element(v)
                     cur.append(ele)
             else:


### PR DESCRIPTION
Hello! I corrected in the xmlparser a line which introduced an error when an attribute contained multiple 'None' values. The error occurred in my case for a property with two values where the possible uncertainties for each value are set to None. I think in my case I could work around this, since both values are 'None', but it would be more difficult in cases with two values and only one uncertainty is None. 
Have a look, if you would like to integrate this correction. Let me know if you have more questions on this.

Best Lyuba