### PR TITLE
Remove unused fields

### DIFF
--- a/odml/dtypes.py
+++ b/odml/dtypes.py
@@ -1,6 +1,5 @@
 """
-Provides functionality for validation of the data-types specified
-for odml
+Provides functionality for validation of the data-types specified for odml
 """
 
 import sys
@@ -11,6 +10,11 @@ import datetime
 import binascii
 import hashlib
 from enum import Enum
+
+try:
+    unicode = unicode
+except NameError:
+    unicode = str
 
 
 class DType(str, Enum):

--- a/odml/dtypes.py
+++ b/odml/dtypes.py
@@ -1,5 +1,5 @@
 """
-Provides functionality for validation of the data-types specified for odml
+Provides functionality for validation of the data-types specified for odML
 """
 
 import sys
@@ -276,35 +276,3 @@ def binary_set(value, encoding=None):
     return encodings[encoding].encode(value)
 
 
-def calculate_crc32_checksum(data):
-    if sys.version_info < (3, 0):
-        return "%08x" % (binascii.crc32(data) & 0xffffffff)
-    else:
-        if isinstance(data, str):
-            data = str.encode(data)
-        return "%08x" % (binascii.crc32(data) & 0xffffffff)
-
-
-
-checksums = {
-    'crc32': calculate_crc32_checksum,
-}
-
-# allow to use any available algorithm
-if sys.version_info > (3, 0):
-    for algo in hashlib.algorithms_guaranteed:
-        checksums[algo] = lambda data, func=getattr(hashlib, algo): func(data).hexdigest()
-elif not sys.version_info < (2, 7):
-    for algo in hashlib.algorithms:
-        checksums[algo] = lambda data, func=getattr(hashlib, algo): func(data).hexdigest()
-
-
-def valid_checksum_type(checksum_type):
-    return checksum_type in checksums
-
-
-def calculate_checksum(data, checksum_type):
-    if data is None: data = ''
-    if isinstance(data, str):
-        data = str.encode(data)
-    return checksums[checksum_type](data)

--- a/odml/dtypes.py
+++ b/odml/dtypes.py
@@ -116,7 +116,7 @@ def set(value, dtype=None, encoding=None):
     if dtype.endswith("-tuple"):
         return tuple_set(value)
     if dtype == "binary":
-        return binary_set(value, encoding)
+        return binary_set(value)
     if sys.version_info > (3, 0):
         if isinstance(value, str):
             return str_set(value)

--- a/odml/format.py
+++ b/odml/format.py
@@ -40,9 +40,6 @@ class Value(Format):
         'type': 0,
         'definition': 0,
         'reference': 0,
-        'filename': 0,
-        'checksum': 0,
-        'encoder': 0
         }
     _map = {'type': 'dtype'}
 

--- a/odml/tools/jsonparser.py
+++ b/odml/tools/jsonparser.py
@@ -7,6 +7,11 @@ import sys
 import odml
 import json
 
+try:
+    unicode = unicode
+except NameError:
+    unicode = str
+
 
 class OdmlSerializer(object):
     """

--- a/odml/tools/xmlparser.py
+++ b/odml/tools/xmlparser.py
@@ -7,6 +7,7 @@ Parses odML files. Can be invoked standalone:
     python -m odml.tools.xmlparser file.odml
 """
 #TODO make this module a parser class, allow arguments (e.g. skip_errors=1 to parse even broken documents)
+import sys
 
 from odml import format
 from lxml import etree as ET
@@ -15,7 +16,11 @@ from lxml.builder import E
 # this is needed for py2exe to include lxml completely
 from lxml import _elementpath as _dummy
 
-import sys
+try:
+    unicode = unicode
+except NameError:
+    unicode = str
+
 try:
     from StringIO import StringIO
 except ImportError:

--- a/odml/value.py
+++ b/odml/value.py
@@ -32,19 +32,6 @@ class BaseValue(base.baseobject, Value):
     reference (optional)
         an external reference number (e.g. entry in a database)
 
-    filename (optional)
-        the default file name which should be used when saving the object
-
-    encoder (encoder)
-        binary content must be encoded into ascii to be included in odML files.
-        Currently supported is only base64
-
-    checksum (optional)
-        if binary content is directly included or if the URL of an external file is given,
-        a checksum entry can be used to validate the file's identity, integrity.
-        Use this element to indicate the algorithm and the checksum in the format algorithm$checksum
-        e.g. crc32$b84892a2 or md5$d41d8cd98f00b204e9800998ecf8427e
-
     definition (optional)
         additional comments on the value of the property
 
@@ -56,8 +43,8 @@ class BaseValue(base.baseobject, Value):
 
     _format = format.Value
 
-    def __init__(self, data=None, uncertainty=None, unit=None, dtype=None, definition=None, reference=None,
-                 filename=None, encoder=None, checksum=None, comment=None, value=None):
+    def __init__(self, data=None, uncertainty=None, unit=None, dtype=None,
+                 definition=None, reference=None, comment=None, value=None):
         if data is None and value is None:
             raise TypeError("either data or value has to be set")
         if data is not None and value is not None:
@@ -69,21 +56,15 @@ class BaseValue(base.baseobject, Value):
         self._dtype = dtype
         self._definition = definition
         self._reference = reference
-        self._filename = filename
         self._comment = comment
-        self._encoder = encoder
 
         if value is not None:
             # assign value directly (through property would raise a change-event)
-            self._value = dtypes.get(value, self._dtype, self._encoder)
+            self._value = dtypes.get(value, self._dtype)
         elif data is not None:
             if dtype is None:
                 self._dtype = dtypes.infer_dtype(data)
             self._value = data
-
-        self._checksum_type = None
-        if checksum is not None:
-            self.checksum = checksum
 
     def __repr__(self):
         if self._dtype:
@@ -124,11 +105,11 @@ class BaseValue(base.baseobject, Value):
         >>> v.data
         2.0
         """
-        return dtypes.set(self._value, self._dtype, self._encoder)
+        return dtypes.set(self._value, self._dtype)
 
     @value.setter
     def value(self, new_string):
-        self._value = dtypes.get(new_string, self._dtype, self._encoder)
+        self._value = dtypes.get(new_string, self._dtype)
 
     @property
     def dtype(self):
@@ -150,45 +131,19 @@ class BaseValue(base.baseobject, Value):
             raise AttributeError("'%s' is not a valid type." % new_type)
         # we convert the value if possible
         old_type = self._dtype
-        old_value = dtypes.set(self._value, self._dtype, self._encoder)
+        old_value = dtypes.set(self._value, self._dtype)
         try:
-            new_value = dtypes.get(old_value, new_type, self._encoder)
+            new_value = dtypes.get(old_value, new_type)
         except:
             # cannot convert, try the other way around
             try:
-                old_value = dtypes.set(self._value, new_type, self._encoder)
-                new_value = dtypes.get(old_value, new_type, self._encoder)
+                old_value = dtypes.set(self._value, new_type)
+                new_value = dtypes.get(old_value, new_type)
             except:
                 #doesn't work either, therefore refuse
                 raise ValueError("cannot convert '%s' from '%s' to '%s'" % (self.value, old_type, new_type))
         self._value = new_value
         self._dtype = new_type
-
-    @property
-    def encoder(self):
-        """
-        the encoding of binary data
-
-        changing the encoding also converts the data
-        """
-        if self._dtype == "binary":
-            return self._encoder
-        return None
-
-    @encoder.setter
-    def encoder(self, encoding):
-        if not self._dtype == "binary":
-            raise AttributeError("attribute 'encoding' can only be set for binary types, not for '%s'" % self._dtype)
-
-        if not encoding:
-            encoding = None
-
-        if not dtypes.valid_encoding(encoding):
-            raise AttributeError("'%s' is not a valid encoding" % encoding)
-
-        # no need to cast anything here, because the encoding
-        # effects only the display, not the representation
-        self._encoder = encoding
 
     @property
     def uncertainty(self):
@@ -230,41 +185,6 @@ class BaseValue(base.baseobject, Value):
     def comment(self, new_value):
         self._comment = new_value
 
-    @property
-    def filename(self):
-        return self._filename
-
-    @filename.setter
-    def filename(self, new_value):
-        self._filename = new_value
-
-    @property
-    def checksum(self):
-        if not self._dtype == "binary":
-            return None
-        cs_type = self._checksum_type
-        if cs_type is None:
-            cs_type = "crc32"
-        return "%s$%s" % (cs_type, self.calculate_checksum(cs_type))
-
-    @checksum.setter
-    def checksum(self, value):
-        if not self._dtype == "binary":
-            raise AttributeError("attribute 'checksum' can only be set for binary types, not for '%s'" % self._dtype)
-
-        data = value.split("$", 1)
-        if not dtypes.valid_checksum_type(data[0]):
-            raise AttributeError("unsupported checksum type '%s'" % data[0])
-        self._checksum_type = data[0]
-
-    def calculate_checksum(self, cs_type):
-        """
-        returns the checksum for the data of this Value-object
-
-        *cs_type* is the checksum mechanism (e.g. 'crc32' or 'md5')
-        """
-        return dtypes.calculate_checksum(self._value, cs_type)
-
     def can_display(self, text=None, max_length=-1):
         """
         return whether the content of this can be safely displayed in the gui
@@ -278,8 +198,9 @@ class BaseValue(base.baseobject, Value):
             return False
 
         if self._dtype == "binary":
-            unprintable = filter(lambda x: x not in string.printable, text)
-            if self._encoder is None and len(unprintable) > 0:
+            unprintable = list(filter(lambda x: x not in string.printable,
+                                      text))
+            if len(unprintable) > 0:
                 return False
 
         if "\n" in text or "\t" in text:

--- a/odml/value.py
+++ b/odml/value.py
@@ -197,12 +197,6 @@ class BaseValue(base.baseobject, Value):
         if max_length != -1 and len(text) > max_length:
             return False
 
-        if self._dtype == "binary":
-            unprintable = list(filter(lambda x: x not in string.printable,
-                                      text))
-            if len(unprintable) > 0:
-                return False
-
         if "\n" in text or "\t" in text:
             return False
 

--- a/test/test_dtypes.py
+++ b/test/test_dtypes.py
@@ -27,53 +27,6 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(date, typ.datetime_get(date_string))
         self.assertEqual(typ.datetime_set(date), date_string)
 
-    def test_empty_binary(self):
-        v = odml.Value("", dtype="string")
-        v.dtype = "binary"
-        v.encoding = "base64"
-        self.assertIsNone(v.value)
-        v.encoding = "quoted-printable"
-        self.assertIsNone(v.value)
-        v.encoding = "hexadecimal"
-        self.assertIsNone(v.value)
-
-    def test_8bit_binary(self):
-        """
-        data = ''.join([chr(i) for i in range(256)])
-        v = odml.Value(data, dtype="binary")
-
-        v.encoder = "base64"
-        b64_data = 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+/w=='
-        self.assertEqual(v.value, b64_data)
-        v.value = b64_data
-        self.assertEqual(v.data, data)
-        self.assertEqual(v.value, b64_data)
-
-        v.encoder = "quoted-printable"
-        qp_data = '=00=01=02=03=04=05=06=07=08=09\n=0B=0C\r=0E=0F=10=11=12=13=14=15=16=17=18=19=1A=1B=1C=1D=1E=1F !"#$%&\'()*+,-=\n./0123456789:;<=3D>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuv=\nwxyz{|}~=7F=80=81=82=83=84=85=86=87=88=89=8A=8B=8C=8D=8E=8F=90=91=92=93=94=\n=95=96=97=98=99=9A=9B=9C=9D=9E=9F=A0=A1=A2=A3=A4=A5=A6=A7=A8=A9=AA=AB=AC=AD=\n=AE=AF=B0=B1=B2=B3=B4=B5=B6=B7=B8=B9=BA=BB=BC=BD=BE=BF=C0=C1=C2=C3=C4=C5=C6=\n=C7=C8=C9=CA=CB=CC=CD=CE=CF=D0=D1=D2=D3=D4=D5=D6=D7=D8=D9=DA=DB=DC=DD=DE=DF=\n=E0=E1=E2=E3=E4=E5=E6=E7=E8=E9=EA=EB=EC=ED=EE=EF=F0=F1=F2=F3=F4=F5=F6=F7=F8=\n=F9=FA=FB=FC=FD=FE=FF'
-        self.assertEqual(v.value, qp_data)
-        v.value = qp_data
-        self.assertEqual(v.data, data)
-        self.assertEqual(v.value, qp_data)
-
-        v.encoder = "hexadecimal"
-        hex_data = '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff'
-        self.assertEqual(v.value, hex_data)
-        v.value = hex_data
-        self.assertEqual(v.data, data)
-        self.assertEqual(v.value, hex_data)
-
-        self.assertEqual(v.checksum, 'crc32$29058c73')
-        v.checksum = "md5"
-        self.assertEqual(v.checksum, 'md5$e2c865db4162bed963bfaa9ef6ac18f0')
-        v.encoder = ''
-        v.data = v.data[:127] # chrs > 128 cannot be converted to ascii
-        v.dtype = "string"
-        self.assertIsNone(v.encoder)
-        self.assertIsNone(v.checksum)
-        self.assertEqual(v.value, data[:127])
-        """
-
     def test_int(self):
         v = odml.Value(value="123456789012345678901", dtype="int")
         self.assertEqual(v.data, 123456789012345678901)

--- a/test/test_dtypes.py
+++ b/test/test_dtypes.py
@@ -36,9 +36,6 @@ class TestTypes(unittest.TestCase):
         self.assertIsNone(v.value)
         v.encoding = "hexadecimal"
         self.assertIsNone(v.value)
-        self.assertEqual(v.checksum, 'crc32$00000000')
-        v.checksum = "md5"
-        self.assertEqual(v.checksum, 'md5$d41d8cd98f00b204e9800998ecf8427e')
 
     def test_8bit_binary(self):
         """


### PR DESCRIPTION
A wonderful PR full of red lines.

Removes unused Value fields: checksum, filename, encoder.
Removes supporting functions: checksum calculation, encoder conversion.
Removes support for binary dtypes.

Closes #50.