### PR TITLE
replace e.message by e.msg

### DIFF
--- a/odml/tools/xmlparser.py
+++ b/odml/tools/xmlparser.py
@@ -160,14 +160,14 @@ class XMLReader(object):
         try:
             root = ET.parse(xml_file, self.parser).getroot()
         except ET.XMLSyntaxError as e:
-            raise ParserException(e.message)
+            raise ParserException(e.msg)
         return self.parse_element(root)
 
     def fromString(self, string):
         try:
             root = ET.XML(string, self.parser)
         except ET.XMLSyntaxError as e:
-            raise ParserException(e.message)
+            raise ParserException(e.msg)
         return self.parse_element(root)
 
     def check_mandatory_arguments(self, data, ArgClass, tag_name, node):


### PR DESCRIPTION

Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/threading.py", line 914, in _bootstrap_inner
    self.run()
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/threading.py", line 862, in run
    self._target(*self._args, **self._kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/odML-1.3.dev0-py3.5.egg/odml/terminology.py", line 76, in _load
    term = odml.tools.xmlparser.XMLReader(filename=url, ignore_errors=True).fromFile(fp)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/odML-1.3.dev0-py3.5.egg/odml/tools/xmlparser.py", line 163, in fromFile
    raise ParserException(e.message)
AttributeError: 'XMLSyntaxError' object has no attribute 'message'