### PR TITLE
replaced e.message by e in terminology.py

### DIFF
--- a/odml/terminology.py
+++ b/odml/terminology.py
@@ -77,7 +77,7 @@ class Terminologies(dict):
             term.finalize()
         except odml.tools.xmlparser.ParserException as e:
             print("Failed to load %s due to parser errors" % url)
-            print(' "%s"' % e.message)
+            print(' "%s"' % e)
             term = None
         self[url] = term
         return term


### PR DESCRIPTION
I suggest replacing e.message by e to avoid the following exception.

Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/threading.py", line 914, in _bootstrap_inner
    self.run()
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/threading.py", line 862, in run
    self._target(*self._args, **self._kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/odML-1.3.dev0-py3.5.egg/odml/terminology.py", line 80, in _load
    print(' "%s"' % e.message)
AttributeError: 'ParserException' object has no attribute 'message'