### PR TITLE
Appending arbitrary number of Sections/Properties in one go and property addition to a document 

### DIFF
--- a/odml/base.py
+++ b/odml/base.py
@@ -137,15 +137,14 @@ class SmartList(SafeList):
                 return True
 
     def append(self, *obj_tuple):
-        ll = len(obj_tuple)
-        for i in list(range(0,ll)):
-                if obj_tuple[i].name in self:
-                    raise KeyError("Object with the same name already exists! " + str(obj_tuple[i]))
-                from odml.section import BaseSection
-                from odml.doc import BaseDocument
-                if (not isinstance(obj_tuple[i], BaseSection)) & isinstance(self,BaseDocument):
-                    raise KeyError("Object " + str(obj_tuple[i]) + " is not a Section.")
-                super(SmartList, self).append(obj_tuple[i])
+        from odml.section import BaseSection
+        from odml.doc import BaseDocument
+        for obj in obj_tuple:
+                if obj.name in self:
+                    raise KeyError("Object with the same name already exists! " + str(obj))
+                if (not isinstance(obj, BaseSection)) & isinstance(self, BaseDocument):
+                    raise KeyError("Object " + str(obj) + " is not a Section.")
+                super(SmartList, self).append(obj)
 
 
 
@@ -182,16 +181,15 @@ class sectionable(baseobject):
         self._sections.append(section)
         section._parent = self
 
-    def append(self, *vsection):
+    def append(self, *vsection_tuple):
         """adds the section to the section-list and makes this document the section’s parent"""
-        ll = len(vsection)
-        for i in list(range(0,ll)):
-             from odml.section import BaseSection
-             from odml.doc import BaseDocument
-             if (not isinstance(vsection[i], BaseSection)) & isinstance(self,BaseDocument):
-                raise KeyError("Object " + str(vsection[i]) + " is not a Section.")
-             self._sections.append(vsection[i])
-             vsection[i]._parent = self
+        from odml.section import BaseSection
+        from odml.doc import BaseDocument
+        for vsection in vsection_tuple:
+             if (not isinstance(vsection, BaseSection)) & isinstance(self,BaseDocument):
+                raise KeyError("Object " + str(vsection) + " is not a Section.")
+             self._sections.append(vsection)
+             vsection._parent = self
  
 
     @inherit_docstring

--- a/odml/base.py
+++ b/odml/base.py
@@ -136,11 +136,17 @@ class SmartList(SafeList):
             if (hasattr(obj, "name") and obj.name == key) or key == obj:
                 return True
 
-    def append(self, obj):
-        if obj.name in self:
-            raise KeyError("Object with the same name already exists! " + str(obj))
-        else:
-            super(SmartList, self).append(obj)
+    def append(self, *obj_tuple):
+        ll = len(obj_tuple)
+        for i in list(range(0,ll)):
+                if obj_tuple[i].name in self:
+                    raise KeyError("Object with the same name already exists! " + str(obj_tuple[i]))
+                from odml.section import BaseSection
+                from odml.doc import BaseDocument
+                if (not isinstance(obj_tuple[i], BaseSection)) & isinstance(self,BaseDocument):
+                    raise KeyError("Object " + str(obj_tuple[i]) + " is not a Section.")
+                super(SmartList, self).append(obj_tuple[i])
+
 
 
 @allow_inherit_docstring
@@ -176,10 +182,17 @@ class sectionable(baseobject):
         self._sections.append(section)
         section._parent = self
 
-    def append(self, section):
+    def append(self, *vsection):
         """adds the section to the section-list and makes this document the section’s parent"""
-        self._sections.append(section)
-        section._parent = self
+        ll = len(vsection)
+        for i in list(range(0,ll)):
+             from odml.section import BaseSection
+             from odml.doc import BaseDocument
+             if (not isinstance(vsection[i], BaseSection)) & isinstance(self,BaseDocument):
+                raise KeyError("Object " + str(vsection[i]) + " is not a Section.")
+             self._sections.append(vsection[i])
+             vsection[i]._parent = self
+ 
 
     @inherit_docstring
     def reorder(self, new_index):

--- a/odml/section.py
+++ b/odml/section.py
@@ -194,9 +194,8 @@ class BaseSection(base.sectionable, Section):
 
     def append(self, *obj_tuple):
         """append Sections or Properties"""
-        ll = len(obj_tuple)
-        for i in list(range(0,ll)):
-            self.__append(obj_tuple[i])
+        for obj in obj_tuple:
+            self.__append(obj)
 
     def insert(self, position, obj):
         """insert a Section or Property at the respective position"""

--- a/odml/section.py
+++ b/odml/section.py
@@ -181,7 +181,7 @@ class BaseSection(base.sectionable, Section):
         """
         return self._merged
 
-    def append(self, obj):
+    def __append(self, obj):
         """append a Section or Property"""
         if isinstance(obj, Section):
             self._sections.append(obj)
@@ -191,6 +191,12 @@ class BaseSection(base.sectionable, Section):
             obj._section = self
         else:
             raise ValueError("Can only append sections and properties")
+
+    def append(self, *obj_tuple):
+        """append Sections or Properties"""
+        ll = len(obj_tuple)
+        for i in list(range(0,ll)):
+            self.__append(obj_tuple[i])
 
     def insert(self, position, obj):
         """insert a Section or Property at the respective position"""

--- a/test/test_mdoc.py
+++ b/test/test_mdoc.py
@@ -1,0 +1,40 @@
+import odml
+import unittest
+import datetime as dt
+
+class TestMultiAppendDoc(unittest.TestCase):
+
+	def test_mdoc(self):
+         jordan = odml.Document(
+                                author="Michael Jordan",
+                                date=dt.date(1991,9,1),
+                                version=0.01
+                               )
+          
+         mjordan  = odml.Document(
+                                  author="Michael Jordan",
+                                  date=dt.date(1991,9,1),
+                                  version=0.01
+                                  )
+          
+         section_bulls = odml.Section(
+                                      name="Chicago_Bulls",
+                                      definition="NBA team based in Chicago, IL",
+                                      type="team"
+                                     )
+
+
+         section_nc  = odml.Section(
+                                    name="North_Caroline",
+                                    definition="NCAA team based in Wilmington, NC",
+                                    type="team"
+                                   )
+         jordan.append(section_bulls)
+         jordan.append(section_nc)
+         mjordan.append(
+                         section_bulls,
+                         section_nc,
+                        )
+         self.assertTrue(jordan.sections[0].name == mjordan.sections[0].name)
+         self.assertTrue(jordan.sections[1].name == mjordan.sections[1].name)
+        

--- a/test/test_mdoc_property_add.py
+++ b/test/test_mdoc_property_add.py
@@ -1,0 +1,24 @@
+import odml
+import unittest
+import datetime as dt
+
+class TestAppendProperty(unittest.TestCase):
+
+	def test_mdoc_property_add(self):
+         jordan = odml.Document(
+                                author="Michael Jordan",
+                                date=dt.date(1991,9,1),
+                                version=0.01
+                               )
+ 
+          
+         prop1 = odml.Property(
+                              name="Coach",
+                              value="Phil Jackson",
+                              definition="Run the team."
+                             ) 
+
+     
+         self.assertRaises(KeyError, lambda: jordan.append(prop1))
+   
+        

--- a/test/test_msec.py
+++ b/test/test_msec.py
@@ -1,0 +1,59 @@
+import odml
+import unittest
+
+class TestMultiAppendDoc(unittest.TestCase):
+
+    def test_msec(self):
+        # Test case for odml_msec
+        section_bulls = odml.Section(
+                                     name="Chicago_Bulls",
+                                     definition="NBA team based in Chicago, IL",
+                                     type="team"
+                                    )
+       
+        section_bulls0 = odml.Section(
+                                      name="Chicago_Bulls",
+                                      definition="NBA team based in Chicago, IL",
+                                      type="team"
+                                      )
+
+        section_bulls2  = odml.Section(
+                                       name="Chicago_City_Pub",
+                                       definition="NBA team pub",
+                                       type="pub"
+                                      )
+
+        section_bull3 = odml.Section(
+                                     name="Bill_Clinton",
+                                     definition="President supporter",
+                                     type="fan"
+                                    )
+
+        prop1 = odml.Property(
+                              name="Coach",
+                              value="Phil Jackson",
+                              definition="Run the team."
+                             )
+        
+        prop2 = odml.Property(
+                              name="Euro_player",
+                              value="Tony Kukoc",
+                              definition="European Player"
+                             )
+
+        section_bulls.append(
+                             section_bulls2,
+                             section_bull3,
+                             prop1,
+                             prop2
+                            )
+        
+        section_bulls0.append(section_bulls2)
+        section_bulls0.append(section_bull3)
+        section_bulls0.append(prop1)
+        section_bulls0.append(prop2)
+         
+        self.assertTrue(section_bulls.sections[0].name == section_bulls0.sections[0].name)
+        self.assertTrue(section_bulls.sections[1].name == section_bulls0.sections[1].name)
+        self.assertTrue(section_bulls.properties[0].name == section_bulls0.properties[0].name)
+        self.assertTrue(section_bulls.properties[1].name == section_bulls0.properties[1].name)


### PR DESCRIPTION
* This is a cleaned up  pull request following @jgrewe 's review on the pull request #75 and  #63 with @lzehl, resolving error on checking append object's type.

* Due to too frequent commits from my previous fork, I created a new fork for more readable review. 

* The changes proposed resolves issues #69 and #65.

* New unit tests are introduced and passing. See `diff`.

PS:  Sorry for the traffic to resolve these issues.

