### PR TITLE
Fix Value representation if string contains a '\n' character

### DIFF
--- a/odml/value.py
+++ b/odml/value.py
@@ -216,7 +216,7 @@ class BaseValue(base.baseobject, Value):
         if max_length != -1:
             text = text[:max_length]
         if self.can_display(text, max_length):
-            return text + u'…'
+            return (text + u'…').encode('utf-8')
 
         return "(%d bytes)" % len(self._value)
 


### PR DESCRIPTION
Fixes #79 

To fix this, we can either use the normal ascii characters `...` to append to the string , or encode the whole string using `utf-8`. 

In this PR, I have used the latter approach.
