### PR TITLE
Fix param in ValidateError call & raising RuntimeError.

### DIFF
--- a/odml/section.py
+++ b/odml/section.py
@@ -293,7 +293,7 @@ class BaseSection(base.sectionable, Section):
         to the linked object
         """
         if self == section:
-            raise RuntimeException("cannot unmerge myself?")
+            raise RuntimeError("cannot unmerge myself?")
         removals = []
         for obj in section:
             mine = self.contains(obj)

--- a/odml/validation.py
+++ b/odml/validation.py
@@ -114,7 +114,7 @@ def section_repository_should_be_present(sec):
     try:
         tsec = sec.get_terminology_equivalent()
     except Exception as e:
-        yield ValidationError(sec, 'Could not load terminology: ' + e.message, 'warning')
+        yield ValidationError(sec, 'Could not load terminology: ' % e, 'warning')
         return
 
     if tsec is None:

--- a/odml/validation.py
+++ b/odml/validation.py
@@ -114,7 +114,7 @@ def section_repository_should_be_present(sec):
     try:
         tsec = sec.get_terminology_equivalent()
     except Exception as e:
-        yield ValidationError(sec, 'Could not load terminology: ' % e, 'warning')
+        yield ValidationError(sec, 'Could not load terminology: %s' % e, 'warning')
         return
 
     if tsec is None:


### PR DESCRIPTION
- [validation] Fix param in ValidateError call due to AttributeError: 'object has no attribute 'message'.
- [section] Fix raising RuntimeError.