### PR TITLE
Add update of a parent about a new son.

### DIFF
--- a/odml/property.py
+++ b/odml/property.py
@@ -102,7 +102,7 @@ class BaseProperty(base.baseobject, Property):
     @parent.setter
     def parent(self, new_parent):
         if new_parent is None:
-            return
+            self._parent = None
         elif self._validate_parent(new_parent):
             self._parent = new_parent
             self._parent.append(self)

--- a/odml/property.py
+++ b/odml/property.py
@@ -101,9 +101,14 @@ class BaseProperty(base.baseobject, Property):
 
     @parent.setter
     def parent(self, new_parent):
-        if new_parent is None:
+        if new_parent is None and self._parent is None:
+            return
+        elif new_parent is None and self._parent is not None:
+            self._parent.remove(self)
             self._parent = None
         elif self._validate_parent(new_parent):
+            if self._parent is not None:
+                self._parent.remove(self)
             self._parent = new_parent
             self._parent.append(self)
         else:

--- a/odml/section.py
+++ b/odml/section.py
@@ -176,7 +176,7 @@ class BaseSection(base.sectionable, Section):
                              "odml.Document or odml.Section expected")
 
     def _validate_parent(self, new_parent):
-        if isinstance(new_parent, BaseDocument) | isinstance(new_parent, BaseSection):
+        if isinstance(new_parent, BaseDocument) or isinstance(new_parent, BaseSection):
             return True
         return False
 

--- a/odml/section.py
+++ b/odml/section.py
@@ -167,7 +167,7 @@ class BaseSection(base.sectionable, Section):
     @parent.setter
     def parent(self, new_parent):
         if new_parent is None:
-            return
+            self._parent = None
         elif self._validate_parent(new_parent):
             self._parent = new_parent
             self._parent.append(self)

--- a/odml/section.py
+++ b/odml/section.py
@@ -5,6 +5,7 @@ import odml.terminology as terminology
 from odml.property import Property  # this is supposedly ok, as we only use it for an isinstance check
                                     # it MUST however not be used to create any Property objects
 from odml.tools.doc_inherit import inherit_docstring, allow_inherit_docstring
+from odml.doc import BaseDocument
 
 
 class Section(base._baseobj):
@@ -175,7 +176,6 @@ class BaseSection(base.sectionable, Section):
                              "odml.Document or odml.Section expected")
 
     def _validate_parent(self, new_parent):
-        from odml.doc import BaseDocument
         if isinstance(new_parent, BaseDocument) | isinstance(new_parent, BaseSection):
             return True
         return False

--- a/odml/section.py
+++ b/odml/section.py
@@ -166,9 +166,14 @@ class BaseSection(base.sectionable, Section):
 
     @parent.setter
     def parent(self, new_parent):
-        if new_parent is None:
+        if new_parent is None and self._parent is None:
+            return
+        elif new_parent is None and self._parent is not None:
+            self._parent.remove(self)
             self._parent = None
         elif self._validate_parent(new_parent):
+            if self._parent is not None:
+                self._parent.remove(self)
             self._parent = new_parent
             self._parent.append(self)
         else:

--- a/odml/section.py
+++ b/odml/section.py
@@ -24,13 +24,14 @@ class BaseSection(base.sectionable, Section):
     _format = format.Section
 
     def __init__(self, name, type=None, parent=None, definition=None):
-        self._parent = parent
+        self._parent = None
         self._name = name
         self._props = base.SmartList()
         self._definition = definition
         super(BaseSection, self).__init__()
         # this may fire a change event, so have the section setup then
         self.type = type
+        self.parent = parent
 
     def __repr__(self):
         return "<Section %s[%s] (%d)>" % (self._name, self.type, len(self._sections))
@@ -153,6 +154,23 @@ class BaseSection(base.sectionable, Section):
         """the parent section, the parent document or None"""
         return self._parent
 
+    @parent.setter
+    def parent(self, new_parent):
+        if new_parent is None:
+            return
+        elif self._validate_parent(new_parent):
+            self._parent = new_parent
+            self._parent.append(self)
+        else:
+            raise ValueError("odml.Section.parent: passed value is not of consistent type! \n"
+                             "odml.Document or odml.Section expected")
+
+    def _validate_parent(self, new_parent):
+        from odml.doc import BaseDocument
+        if isinstance(new_parent, BaseDocument) | isinstance(new_parent, BaseSection):
+            return True
+        return False
+
     def get_repository(self):
         """
         returns the repository responsible for this section,
@@ -188,7 +206,7 @@ class BaseSection(base.sectionable, Section):
             obj._parent = self
         elif isinstance(obj, Property):
             self._props.append(obj)
-            obj._section = self
+            obj._parent = self
         else:
             raise ValueError("Can only append sections and properties")
 

--- a/odml/section.py
+++ b/odml/section.py
@@ -23,11 +23,12 @@ class BaseSection(base.sectionable, Section):
 
     _format = format.Section
 
-    def __init__(self, name, type=None, parent=None, definition=None):
+    def __init__(self, name, type=None, parent=None, definition=None, reference=None):
         self._parent = None
         self._name = name
         self._props = base.SmartList()
         self._definition = definition
+        self._reference = reference
         super(BaseSection, self).__init__()
         # this may fire a change event, so have the section setup then
         self.type = type
@@ -135,6 +136,14 @@ class BaseSection(base.sectionable, Section):
     @definition.deleter
     def definition(self):
         del self._definition
+
+    @property
+    def reference(self):
+        return self._reference
+
+    @reference.setter
+    def reference(self, new_value):
+        self._reference = new_value
 
     # API (public)
     #

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -28,6 +28,11 @@ class TestProperty(unittest.TestCase):
         self.assertIsInstance(p.parent, BaseSection)
         self.assertIsInstance(p.parent._props[0], BaseProperty)
 
+        prop_parent = p.parent
+        p.parent = None
+        self.assertIsNone(p.parent)
+        self.assertEqual(len(prop_parent._props), 0)
+
         with self.assertRaises(ValueError):
             Property("property_prop", parent=Property("P"))
         with self.assertRaises(ValueError):

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -1,6 +1,7 @@
 import unittest
 from odml import Property, Section, Document
 from odml.section import BaseSection
+from odml.property import BaseProperty
 
 
 class TestProperty(unittest.TestCase):
@@ -19,6 +20,14 @@ class TestProperty(unittest.TestCase):
         p = Property("property_section", parent=Section("S"))
         self.assertIsInstance(p.parent, BaseSection)
         self.assertEqual(len(p.parent._props), 1)
+
+        """ test if child is removed from _props of a parent after assigning a new parent to the child """
+        prop_parent = p.parent
+        p.parent = Section("S1")
+        self.assertEqual(len(prop_parent._props), 0)
+        self.assertIsInstance(p.parent, BaseSection)
+        self.assertIsInstance(p.parent._props[0], BaseProperty)
+
         with self.assertRaises(ValueError):
             Property("property_prop", parent=Property("P"))
         with self.assertRaises(ValueError):

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -1,6 +1,5 @@
 import unittest
 from odml import Property, Section, Document
-from odml.doc import BaseDocument
 from odml.section import BaseSection
 
 
@@ -31,46 +30,5 @@ class TestProperty(unittest.TestCase):
     def test_path(self):
         pass
 
-
-class TestSection(unittest.TestCase):
-    def setUp(self):
-        pass
-
-    def test_value(self):
-        pass
-
-    def test_name(self):
-        pass
-
-    def test_parent(self):
-        s = Section("Section")
-        self.assertIsNone(s.parent)
-
-        s = Section("section_doc", parent=Document())
-        self.assertIsInstance(s.parent, BaseDocument)
-        self.assertEqual(len(s.parent._sections), 1)
-
-        s = Section("section_sec", parent=Section("S"))
-        self.assertIsInstance(s.parent, BaseSection)
-        self.assertEqual(len(s.parent._sections), 1)
-
-        with self.assertRaises(ValueError):
-            Section("section_property", parent=Property("P"))
-
-    def test_dtype(self):
-        pass
-
-    def test_path(self):
-        pass
-
-if __name__ == "__main__":
-    print("TestProperty")
-    tp = TestProperty()
-    tp.test_value()
-    tp.test_parent()
-
-    print("TestSection")
-    ts = TestSection()
-    ts.test_parent()
 
 

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -1,4 +1,6 @@
 import unittest
+from odml.section import BaseSection
+from odml.property import BaseProperty
 from odml import Property, Section, Document, DType
 
 

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -1,5 +1,7 @@
 import unittest
 from odml import Property, Section, Document
+from odml.doc import BaseDocument
+from odml.section import BaseSection
 
 
 class TestProperty(unittest.TestCase):
@@ -9,13 +11,51 @@ class TestProperty(unittest.TestCase):
 
     def test_value(self):
         p = Property("property", 100)
-        assert(p.value[0] == 100)
+        self.assertEqual(p.value[0], 100)
 
     def test_name(self):
         pass
 
     def test_parent(self):
+        p = Property("property_section", parent=Section("S"))
+        self.assertIsInstance(p.parent, BaseSection)
+        self.assertEqual(len(p.parent._props), 1)
+        with self.assertRaises(ValueError):
+            Property("property_prop", parent=Property("P"))
+        with self.assertRaises(ValueError):
+            Property("property_doc", parent=Document())
+
+    def test_dtype(self):
         pass
+
+    def test_path(self):
+        pass
+
+
+class TestSection(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_value(self):
+        pass
+
+    def test_name(self):
+        pass
+
+    def test_parent(self):
+        s = Section("Section")
+        self.assertIsNone(s.parent)
+
+        s = Section("section_doc", parent=Document())
+        self.assertIsInstance(s.parent, BaseDocument)
+        self.assertEqual(len(s.parent._sections), 1)
+
+        s = Section("section_sec", parent=Section("S"))
+        self.assertIsInstance(s.parent, BaseSection)
+        self.assertEqual(len(s.parent._sections), 1)
+
+        with self.assertRaises(ValueError):
+            Section("section_property", parent=Property("P"))
 
     def test_dtype(self):
         pass
@@ -27,3 +67,10 @@ if __name__ == "__main__":
     print("TestProperty")
     tp = TestProperty()
     tp.test_value()
+    tp.test_parent()
+
+    print("TestSection")
+    ts = TestSection()
+    ts.test_parent()
+
+

--- a/test/test_section.py
+++ b/test/test_section.py
@@ -17,14 +17,32 @@ class TestSection(unittest.TestCase):
     def test_parent(self):
         s = Section("Section")
         self.assertIsNone(s.parent)
+        s.parent = None
+        self.assertIsNone(s.parent)
+        s.parent = Document()
+        self.assertIsInstance(s.parent, BaseDocument)
+        self.assertIsInstance(s.parent._sections[0], BaseSection)
+
+        """ test if child is removed from _sections of a parent after assigning a new parent to the child """
+        p = s.parent
+        s.parent = Section("S")
+        self.assertEqual(len(p._sections), 0)
 
         s = Section("section_doc", parent=Document())
         self.assertIsInstance(s.parent, BaseDocument)
         self.assertEqual(len(s.parent._sections), 1)
+        p = s.parent
+        s.parent = None
+        self.assertEqual(len(p._sections), 0)
+        self.assertEqual(s.parent, None)
 
         s = Section("section_sec", parent=Section("S"))
         self.assertIsInstance(s.parent, BaseSection)
         self.assertEqual(len(s.parent._sections), 1)
+        p = s.parent
+        s.parent = None
+        self.assertEqual(len(p._sections), 0)
+        self.assertEqual(s.parent, None)
 
         with self.assertRaises(ValueError):
             Section("section_property", parent=Property("P"))

--- a/test/test_section.py
+++ b/test/test_section.py
@@ -1,0 +1,36 @@
+import unittest
+from odml import Property, Section, Document
+from odml.doc import BaseDocument
+from odml.section import BaseSection
+
+
+class TestSection(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_value(self):
+        pass
+
+    def test_name(self):
+        pass
+
+    def test_parent(self):
+        s = Section("Section")
+        self.assertIsNone(s.parent)
+
+        s = Section("section_doc", parent=Document())
+        self.assertIsInstance(s.parent, BaseDocument)
+        self.assertEqual(len(s.parent._sections), 1)
+
+        s = Section("section_sec", parent=Section("S"))
+        self.assertIsInstance(s.parent, BaseSection)
+        self.assertEqual(len(s.parent._sections), 1)
+
+        with self.assertRaises(ValueError):
+            Section("section_property", parent=Property("P"))
+
+    def test_dtype(self):
+        pass
+
+    def test_path(self):
+        pass


### PR DESCRIPTION
Following issue #93 discussions.
- Add optional `parent` attribute to *args of a Property.
- Change `_section` attr to `_parent` in Property.
- Add update about a new children when a parent is provided as *args in Section and Property.
- Add `reference` attribute as optional *args of a Section.
- Add `_reference` attribute to attributes of a Section.
- Add tests to TestProperty class to cover update parent functionality. 