### PR TITLE
DType boolean conversion of values

### DIFF
--- a/odml/dtypes.py
+++ b/odml/dtypes.py
@@ -200,12 +200,12 @@ def datetime_set(value):
 def boolean_get(string):
     if string is None:
         return None
-    if type(string) is unicode:
+    if isinstance(string, unicode):
         string = string.lower()
-    truth = ["true", "1", True]  # be kind, spec only accepts True / False
+    truth = ["true", "1", True, "t"]  # be kind, spec only accepts True / False
     if string in truth:
         return True
-    false = ["false", "0", False]
+    false = ["false", "0", False, "f"]
     if string in false:
         return False
     return bool(string)

--- a/odml/dtypes.py
+++ b/odml/dtypes.py
@@ -200,9 +200,8 @@ def datetime_set(value):
 def boolean_get(string):
     if string is None:
         return None
-    if type(string) is str:
+    if type(string) is unicode:
         string = string.lower()
-
     truth = ["true", "1", True]  # be kind, spec only accepts True / False
     if string in truth:
         return True
@@ -237,4 +236,3 @@ def tuple_set(value):
     if not value:
         return None
     return "(%s)" % ";".join(value)
-

--- a/odml/dtypes.py
+++ b/odml/dtypes.py
@@ -217,6 +217,10 @@ def boolean_set(value):
     return str(value)
 
 
+bool_get = boolean_get
+bool_set = boolean_set
+
+
 def tuple_get(string, count=None):
     """
     parse a tuple string like "(1024;768)" and return strings of the elements

--- a/odml/dtypes.py
+++ b/odml/dtypes.py
@@ -200,16 +200,16 @@ def datetime_set(value):
 def boolean_get(string):
     if string is None:
         return None
-    if type(string) is bool:
-        string = str(string)
-    string = string.lower()
-    truth = ["true", "t", "1"]  # be kind, spec only accepts True / False
+    if type(string) is str:
+        string = string.lower()
+
+    truth = ["true", "1", True]  # be kind, spec only accepts True / False
     if string in truth:
         return True
-    false = ["false", "f", "0"]
+    false = ["false", "0", False]
     if string in false:
         return False
-    raise ValueError("Cannot interpret '%s' as boolean" % string)
+    return bool(string)
 
 
 def boolean_set(value):

--- a/odml/property.py
+++ b/odml/property.py
@@ -91,6 +91,7 @@ class BaseProperty(base.baseobject, Property):
             self._dtype = new_type
             self.value = old_values
         except:
+            self._dtype = old_type  # If conversion failed, restore old dtype
             raise ValueError("cannot convert from '%s' to '%s'" % (old_type, new_type))
 
     @property

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -1,5 +1,5 @@
 import unittest
-from odml import Property, Section, Document
+from odml import Property, Section, Document, DType
 
 
 class TestProperty(unittest.TestCase):
@@ -10,6 +10,21 @@ class TestProperty(unittest.TestCase):
     def test_value(self):
         p = Property("property", 100)
         assert(p.value[0] == 100)
+
+    def test_bool_conversion(self):
+
+        p = Property(name='received', value=[3, 0, 1, 0, 8])
+        assert(p.dtype == 'int')
+        p.dtype = DType.boolean
+        assert(p.dtype == 'boolean')
+        assert(p.value == [True, False, True, False, True])
+
+        q = Property(name='sent', value=['False', True, 'TRUE', '0'])
+        assert(q.dtype == 'string')
+        q.dtype = DType.boolean
+        assert(q.dtype == 'boolean')
+        assert(q.value == [False, True, True, False])
+
 
     def test_name(self):
         pass

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -19,11 +19,11 @@ class TestProperty(unittest.TestCase):
         assert(p.dtype == 'boolean')
         assert(p.value == [True, False, True, False, True])
 
-        q = Property(name='sent', value=['False', True, 'TRUE', '0'])
+        q = Property(name='sent', value=['False', True, 'TRUE', '0', 't', 'F', 'Ft'])
         assert(q.dtype == 'string')
         q.dtype = DType.boolean
         assert(q.dtype == 'boolean')
-        assert(q.value == [False, True, True, False])
+        assert(q.value == [False, True, True, False, True, False, True])
 
     def test_str_to_int_convert(self):
 
@@ -37,10 +37,9 @@ class TestProperty(unittest.TestCase):
         # Failure Test
         p = Property(name='dogs_onboard', value=['7', '20', '1 Dog', 'Seven'])
         assert(p.dtype == 'string')
-        try:
+
+        with self.assertRaises(ValueError):
             p.dtype = DType.int
-        except ValueError as e:
-            assert(str(e) == "cannot convert from 'string' to 'int'")
 
         assert(p.dtype == 'string')
         assert(p.value == ['7', '20', '1 Dog', 'Seven'])
@@ -56,6 +55,7 @@ class TestProperty(unittest.TestCase):
 
     def test_path(self):
         pass
+
 
 if __name__ == "__main__":
     print("TestProperty")

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -25,6 +25,25 @@ class TestProperty(unittest.TestCase):
         assert(q.dtype == 'boolean')
         assert(q.value == [False, True, True, False])
 
+    def test_str_to_int_convert(self):
+
+        # Success Test
+        p = Property(name='cats_onboard', value=['3', '0', '1', '0', '8'])
+        assert(p.dtype == 'string')
+        p.dtype = DType.int
+        assert(p.dtype == 'int')
+        assert(p.value == [3, 0, 1, 0, 8])
+
+        # Failure Test
+        p = Property(name='dogs_onboard', value=['7', '20', '1 Dog', 'Seven'])
+        assert(p.dtype == 'string')
+        try:
+            p.dtype = DType.int
+        except ValueError as e:
+            assert(str(e) == "cannot convert from 'string' to 'int'")
+
+        assert(p.dtype == 'string')
+        assert(p.value == ['7', '20', '1 Dog', 'Seven'])
 
     def test_name(self):
         pass


### PR DESCRIPTION
Changes requested from issue #96 have been implemented.
- Allow conversion to `boolean` DType 
- If the conversion fails, revert the DType to the original DType
- Add Basic tests

Also, the standard Python `bool` cast is used only as a fallback. Initially, the standard values, that usually relate to a boolean value like `"False"`, `True`, `"0"`, etc. have been checked, and cast to the appropriate `bool` value. 

@jgrewe @lzehl  Does this satisfy the requirements of the mentioned issue ?