### PR TITLE
Add generic subclass exporter

### DIFF
--- a/doc/odml_ontology/root-ontology.ttl
+++ b/doc/odml_ontology/root-ontology.ttl
@@ -222,6 +222,37 @@ rdf:Bag rdf:type owl:Class ;
         rdfs:label "Bag" .
 
 
+###  https://g-node.org/projects/odml-rdf#Cell
+:Cell rdf:type owl:Class ;
+      rdfs:subClassOf :Section ;
+      rdfs:comment "Description"^^xsd:string ;
+      rdfs:label "Cell" ;
+      rdfs:seeAlso <http://portal.g-node.org/odml/terminologies/v1.0/cell/cell.xml> .
+
+
+###  https://g-node.org/projects/odml-rdf#CellProperties
+:CellProperties rdf:type owl:Class ;
+                rdfs:subClassOf :Section ;
+                rdfs:comment "Description"^^xsd:string ;
+                rdfs:label "CellProperties" .
+
+
+###  https://g-node.org/projects/odml-rdf#DataAcquisition
+:DataAcquisition rdf:type owl:Class ;
+                 rdfs:subClassOf :Section ;
+                 rdfs:comment "Description"^^xsd:string ;
+                 rdfs:label "DataAcquisition" ;
+                 rdfs:seeAlso <http://portal.g-node.org/odml/terminologies/v1.0/hardware/daq.xml> .
+
+
+###  https://g-node.org/projects/odml-rdf#Dataset
+:Dataset rdf:type owl:Class ;
+         rdfs:subClassOf :Section ;
+         rdfs:comment "Description"^^xsd:string ;
+         rdfs:label "Dataset" ;
+         rdfs:seeAlso <http://portal.g-node.org/odml/terminologies/v1.0/dataset/dataset.xml> .
+
+
 ###  https://g-node.org/projects/odml-rdf#Document
 :Document rdf:type owl:Class ;
           rdfs:subClassOf owl:Thing ,
@@ -262,6 +293,30 @@ rdf:Bag rdf:type owl:Class ;
           rdfs:seeAlso "Link to the doc description of site"^^xsd:string .
 
 
+###  https://g-node.org/projects/odml-rdf#Electrode
+:Electrode rdf:type owl:Class ;
+           rdfs:subClassOf :Section ;
+           rdfs:comment "Description"^^xsd:string ;
+           rdfs:label "Electrode" ;
+           rdfs:seeAlso <http://portal.g-node.org/odml/terminologies/v1.0/electrode/electrode.xml> .
+
+
+###  https://g-node.org/projects/odml-rdf#Hardware
+:Hardware rdf:type owl:Class ;
+          rdfs:subClassOf :Section ;
+          rdfs:comment "Description"^^xsd:string ;
+          rdfs:label "Hardware" ;
+          rdfs:seeAlso <http://portal.g-node.org/odml/terminologies/v1.0/hardware/hardware.xml> .
+
+
+###  https://g-node.org/projects/odml-rdf#HardwareSettings
+:HardwareSettings rdf:type owl:Class ;
+                  rdfs:subClassOf :Section ;
+                  rdfs:comment "Description"^^xsd:string ;
+                  rdfs:label "HardwareSettings" ;
+                  rdfs:seeAlso <http://portal.g-node.org/odml/terminologies/v1.0/collection/hardware_settings.xml> .
+
+
 ###  https://g-node.org/projects/odml-rdf#Hub
 :Hub rdf:type owl:Class ;
      rdfs:subClassOf owl:Thing ,
@@ -276,6 +331,14 @@ rdf:Bag rdf:type owl:Class ;
      rdfs:comment "Description of the hub class"^^xsd:string ;
      rdfs:label "Hub" ;
      rdfs:seeAlso "Link to the Hub remote description"^^xsd:string .
+
+
+###  https://g-node.org/projects/odml-rdf#Preparation
+:Preparation rdf:type owl:Class ;
+             rdfs:subClassOf :Section ;
+             rdfs:comment "Description"^^xsd:string ;
+             rdfs:label "Preparation" ;
+             rdfs:seeAlso <http://portal.g-node.org/odml/terminologies/v1.0/preparation/preparation.xml> .
 
 
 ###  https://g-node.org/projects/odml-rdf#Property
@@ -326,6 +389,14 @@ rdf:Bag rdf:type owl:Class ;
           rdfs:seeAlso "Link to the description on the site"^^xsd:string .
 
 
+###  https://g-node.org/projects/odml-rdf#Recording
+:Recording rdf:type owl:Class ;
+           rdfs:subClassOf :Section ;
+           rdfs:comment "Description"^^xsd:string ;
+           rdfs:label "Recording" ;
+           rdfs:seeAlso <http://portal.g-node.org/odml/terminologies/v1.0/recording/recording.xml> .
+
+
 ###  https://g-node.org/projects/odml-rdf#Section
 :Section rdf:type owl:Class ;
          rdfs:subClassOf owl:Thing ,
@@ -372,6 +443,37 @@ rdf:Bag rdf:type owl:Class ;
          rdfs:comment "Comment about section"^^xsd:string ;
          rdfs:label "Section" ;
          rdfs:seeAlso "Link to the doc description of site"^^xsd:string .
+
+
+###  https://g-node.org/projects/odml-rdf#Settings
+:Settings rdf:type owl:Class ;
+          rdfs:subClassOf :Section ;
+          rdfs:comment "Description"^^xsd:string ;
+          rdfs:label "Settings" .
+
+
+###  https://g-node.org/projects/odml-rdf#Setup
+:Setup rdf:type owl:Class ;
+       rdfs:subClassOf :Section ;
+       rdfs:comment "Description"^^xsd:string ;
+       rdfs:label "Setup" ;
+       rdfs:seeAlso <http://portal.g-node.org/odml/terminologies/v1.0/setup/setup.xml> .
+
+
+###  https://g-node.org/projects/odml-rdf#Stimulus
+:Stimulus rdf:type owl:Class ;
+          rdfs:subClassOf :Section ;
+          rdfs:comment "Description of the Stimulus."^^xsd:string ;
+          rdfs:label "Stimulus" ;
+          rdfs:seeAlso <http://portal.g-node.org/odml/terminologies/v1.0/stimulus/stimulus.xml> .
+
+
+###  https://g-node.org/projects/odml-rdf#Subject
+:Subject rdf:type owl:Class ;
+         rdfs:subClassOf :Section ;
+         rdfs:comment "Description"^^xsd:string ;
+         rdfs:label "Subject" ;
+         rdfs:seeAlso <http://portal.g-node.org/odml/terminologies/v1.0/subject/subject.xml> .
 
 
 ###  https://g-node.org/projects/odml-rdf#Terminology

--- a/doc/section_subclasses.yaml
+++ b/doc/section_subclasses.yaml
@@ -1,0 +1,4 @@
+stimulus: Stimulus
+subject: Subject
+Cell properties: CellProperties
+recording: Recording

--- a/doc/section_subclasses.yaml
+++ b/doc/section_subclasses.yaml
@@ -1,4 +1,54 @@
-stimulus: Stimulus
-subject: Subject
-Cell properties: CellProperties
+analysis: Analysis
+analysis/psth: PSTH
+analysis/power_spectrum: PowerSpectrum
+cell: Cell
+dataset: Dataset
+blackrock: Blackrock
+electrode: Electrode
+event: Event
+event_list: EventList
+experiment: Experiment
+experiment/behavior: Behavior
+experiment/electrophysiology: Electrophysiology
+experiment/imaging: Imaging
+experiment/pschophysics: Psychophysics
+hardware_properties: HardwareProperties
+hardware_settings: HardwareSettings
+hardware: Hardware
+hardware/amplifier: Amplifier
+hardware/attenuator: Attenuator
+hardware/camera_objective: CameraObjective
+hardware/daq: DataAcquisition
+hardware/eyetracker: Eyetracker
+hardware/filter: Filter
+hardware/filter_set: Filterset
+hardware/iaq: ImageAcquisition
+hardware/light_source: Lightsource
+hardware/microscope: Microscope
+hardware/microscope_objective: MicroscopeObjective
+hardware/scanner: Scanner
+hardware/stimulus_isolator: StimulusIsolator
+model/lif: Leaky integrate and fire
+model/pif: perfect integrate and fire
+model/multi_compartment: Multi compartment model
+model/single_compartment: One compartment model
+person: Person
+preparation: Preparation
+project: Project
+protocol: protocol
 recording: Recording
+setup: Setup
+stimulus: Stimulus
+stimulus/dc: DC
+stimulus/gabor: Gabor
+stimulus/grating: Grating
+stimulus/pulse: Pulse
+stimulus/movie: Movie
+stimulus/ramp: Ramp
+stimulus/random_dot: RandomDot
+stimulus/sawtooth: Sawtooth
+stimulus/sine_wave: Sinewave
+stimulus/square_wave: Squarewave
+stimulus/white_noise: Whitenoise
+subject: Subject
+carmen_mini: CarmenMini

--- a/odml/tools/rdf_converter.py
+++ b/odml/tools/rdf_converter.py
@@ -101,21 +101,21 @@ class RDFWriter(object):
             # generating nodes for entities: sections, properties and bags of values
             elif (isinstance(fmt, odml.format.Document.__class__) or
                     isinstance(fmt, odml.format.Section.__class__)) and \
-                            k == 'sections' and len(getattr(e, k)) > 0:
+                    k == 'sections' and len(getattr(e, k)) > 0:
                 sections = getattr(e, k)
                 for s in sections:
                     node = URIRef(odmlns + str(s.id))
                     self.g.add((curr_node, fmt.rdf_map(k), node))
                     self.save_element(s, node)
             elif isinstance(fmt, odml.format.Section.__class__) and \
-                            k == 'properties' and len(getattr(e, k)) > 0:
+                    k == 'properties' and len(getattr(e, k)) > 0:
                 properties = getattr(e, k)
                 for p in properties:
                     node = URIRef(odmlns + str(p.id))
                     self.g.add((curr_node, fmt.rdf_map(k), node))
                     self.save_element(p, node)
             elif isinstance(fmt, odml.format.Property.__class__) and \
-                            k == 'value' and len(getattr(e, k)) > 0:
+                    k == 'value' and len(getattr(e, k)) > 0:
                 values = getattr(e, k)
                 bag = URIRef(odmlns + str(uuid.uuid4()))
                 self.g.add((bag, RDF.type, RDF.Bag))

--- a/test/test_rdf_writer.py
+++ b/test/test_rdf_writer.py
@@ -1,6 +1,9 @@
 import datetime
+import os
 import unittest
+from os.path import dirname, abspath
 
+import yaml
 from rdflib import URIRef, Literal
 from rdflib.namespace import XSD, RDF
 
@@ -117,14 +120,17 @@ class TestRDFWriter(unittest.TestCase):
         self.assertEqual(len(list(w.g.subjects(predicate=RDF.li, object=Literal("val")))), 3)
 
     def test_section_subclass(self):
-        subclass = RDFWriter.section_subclasses
+        p = os.path.join(dirname(dirname(abspath(__file__))), 'doc', 'section_subclasses.yaml')
+        with open(p, "r") as f:
+            subclass = yaml.load(f)
+
         doc = odml.Document()
         subclass_key = next(iter(subclass))
         s = odml.Section("S", type=subclass_key)
         doc.append(s)
         w = RDFWriter(doc)
         w.convert_to_rdf()
-        self.assertEqual(len(list(w.g.subjects(predicate=RDF.type, object=URIRef(subclass[subclass_key])))), 1)
+        self.assertEqual(len(list(w.g.subjects(predicate=RDF.type, object=URIRef(odmlns[subclass[subclass_key]])))), 1)
         self.assertEqual(len(list(w.g.subjects(predicate=RDF.type, object=URIRef(odmlns.Section)))), 0)
 
     def test_adding_other_entities_properties(self):

--- a/test/test_rdf_writer.py
+++ b/test/test_rdf_writer.py
@@ -116,6 +116,17 @@ class TestRDFWriter(unittest.TestCase):
         w.convert_to_rdf()
         self.assertEqual(len(list(w.g.subjects(predicate=RDF.li, object=Literal("val")))), 3)
 
+    def test_section_subclass(self):
+        subclass = RDFWriter.section_subclasses
+        doc = odml.Document()
+        subclass_key = next(iter(subclass))
+        s = odml.Section("S", type=subclass_key)
+        doc.append(s)
+        w = RDFWriter(doc)
+        w.convert_to_rdf()
+        self.assertEqual(len(list(w.g.subjects(predicate=RDF.type, object=URIRef(subclass[subclass_key])))), 1)
+        self.assertEqual(len(list(w.g.subjects(predicate=RDF.type, object=URIRef(odmlns.Section)))), 0)
+
     def test_adding_other_entities_properties(self):
         doc = parse("""
             s1[t1]


### PR DESCRIPTION
This PR includes:

- Add section subclasses to ontology. Now it is just a prototype, so `section_subclasses` dict will be extended as mentioned in #151.
- Add generic subclass exporter for sections.

Close #146 #147 