### PR TITLE
Version converter fixes

### DIFF
--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -51,6 +51,7 @@ class VersionConverter(object):
         root = tree.getroot()
         root.set("version", XML_VERSION)
         for prop in root.iter("property"):
+            multiple_values = False
             main_val = None
             for value in prop.iter("value"):
                 if main_val is None:
@@ -65,13 +66,20 @@ class VersionConverter(object):
                             value.remove(val_elem)
                 else:
                     if value.text:
-                        main_val.text += ", " + value.text
+                        if main_val.text:
+                            main_val.text += ", " + value.text
+                            multiple_values = True
+                        else:
+                            main_val.text = value.text
 
                     prop.remove(value)
 
             # remove value element, if it does not contain any actual value
             if not main_val.text:
                 prop.remove(main_val)
+            # multiple values require brackets
+            elif main_val.text and multiple_values:
+                main_val.text = "[" + main_val.text + "]"
 
         return tree
 

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -110,9 +110,9 @@ class VersionConverter(object):
 
                 prop.append(main_val)
 
-            # Exclude unsupported Property attributes
+            # Exclude unsupported Property attributes, ignore comments
             for e in prop:
-                if e.tag not in format.Property._args and e.tag != "value":
+                if e.tag not in format.Property._args and isinstance(e.tag, str):
                     print("[Info] Omitted non-Property attribute '%s: %s/%s'" % (prop_name, e.tag, e.text))
                     prop.remove(e)
 
@@ -126,13 +126,13 @@ class VersionConverter(object):
         for sec in root.iter("section"):
             sec_name = sec.find("name").text
             for e in sec:
-                if e.tag not in format.Section._args and e.tag != "value":
+                if e.tag not in format.Section._args and isinstance(e.tag, str):
                     print("[Info] Omitted non-Section attribute '%s: %s/%s'" % (sec_name, e.tag, e.text))
                     sec.remove(e)
 
-        # Exclude unsupported Document attributes
+        # Exclude unsupported Document attributes, ignore comments
         for e in root:
-            if e.tag not in format.Document._args and e.tag != "value":
+            if e.tag not in format.Document._args and isinstance(e.tag, str):
                 print("[Info] Omitted non-Document attribute '%s/%s'" % (e.tag, e.text))
                 root.remove(e)
 

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -70,6 +70,11 @@ class VersionConverter(object):
                         first_value.text += ", " + value.text
 
                     prop.remove(value)
+
+            # remove value element, if it does not contain any actual value
+            if not first_value.text:
+                prop.remove(first_value)
+
         return tree
 
     @classmethod

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -66,7 +66,9 @@ class VersionConverter(object):
                             value.remove(val_elem)
                     one_value = False
                 else:
-                    first_value.text += ", " + value.text
+                    if value.text:
+                        first_value.text += ", " + value.text
+
                     prop.remove(value)
         return tree
 

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -51,29 +51,27 @@ class VersionConverter(object):
         root = tree.getroot()
         root.set("version", XML_VERSION)
         for prop in root.iter("property"):
-            one_value = True
-            first_value = None
+            main_val = None
             for value in prop.iter("value"):
-                if one_value:
-                    first_value = value
+                if main_val is None:
+                    main_val = value
                     for val_elem in value.iter():
-                        if val_elem.tag != "value" and one_value:
+                        if val_elem.tag != "value":
                             elem_name = cls._version_map[val_elem.tag] \
                                 if val_elem.tag in cls._version_map else val_elem.tag
                             new_elem = ET.Element(elem_name)
                             new_elem.text = val_elem.text
                             value.getparent().append(new_elem)  # appending to the property
                             value.remove(val_elem)
-                    one_value = False
                 else:
                     if value.text:
-                        first_value.text += ", " + value.text
+                        main_val.text += ", " + value.text
 
                     prop.remove(value)
 
             # remove value element, if it does not contain any actual value
-            if not first_value.text:
-                prop.remove(first_value)
+            if not main_val.text:
+                prop.remove(main_val)
 
         return tree
 

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -19,7 +19,8 @@ class VersionConverter(object):
     header = """<?xml version="1.0" encoding="UTF-8"?>\n"""
 
     _version_map = {
-        'type': 'type'
+        'type': 'type',
+        'filename': 'value_origin'
     }
 
     _error_strings = {
@@ -67,6 +68,10 @@ class VersionConverter(object):
                                 new_elem = ET.Element(val_elem.tag)
                                 new_elem.text = val_elem.text
                                 value.getparent().append(new_elem)  # appending to the property
+                            elif val_elem.tag in cls._version_map:
+                                new_elem = ET.Element(cls._version_map[val_elem.tag])
+                                new_elem.text = val_elem.text
+                                value.getparent().append(new_elem)
                             else:
                                 print("[Info] Omitted non-Value attribute '%s: %s/%s'" %
                                       (prop_name, val_elem.tag, val_elem.text))

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -43,7 +43,9 @@ class VersionConverter(object):
             tree = ET.ElementTree(ET.fromstring(filename.getvalue()))
         elif os.path.exists(filename) and os.path.getsize(filename) > 0:
             cls._fix_unmatching_tags(filename)
-            tree = ET.parse(filename)
+            # Make pretty print available by resetting format
+            parser = ET.XMLParser(remove_blank_text=True)
+            tree = ET.parse(filename, parser)
         else:
             print("File \"{}\" has not been converted because it is not a valid path to odml .xml file "
                   "nor io.StringIO object".format(filename))


### PR DESCRIPTION
This PR
- Fixes #181 by putting brackets around multiple values (not single values though).
- Fixes #182 where the converter would crash on an empty secondary multiple value.
- Closes #183 by only exporting attributes actually supported by `document`, `section` and `property` and displaying information about any not-exported fields.
- Closes #184 by checking all multiple value attributes like `unit` and `uncertainty` and displaying warnings if information would be potentially lost.
- Closes #185 by exporting `value.filename` to `property.value_origin`.
- Inhibits the export of empty values e.g. when converting a terminology that has `unit` but no actual value.
- Removes the format when opening an XML file to make `pretty_print` available after the conversion.
- Excludes Properties without a name tag with a warning.
