### PR TITLE
[1.3] Version handling, parser fixes, setup update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,10 @@ matrix:
         - python: "3.4"
         - python: "3.5"
 
-before_install:
-  - sudo apt-get -qq  update
-  - sudo apt-get install -y python-enum python-lxml
-
 install:
   - export PYVER=${TRAVIS_PYTHON_VERSION:0:1}
   - pip install --upgrade coveralls
+  - pip install lxml enum34 pyyaml
 
 script:
   - python setup.py build

--- a/odml/__init__.py
+++ b/odml/__init__.py
@@ -5,10 +5,10 @@ from . import property
 from . import section
 from .dtypes import DType
 from .fileio import load, save, display
+from .info import VERSION
 from .tools.odmlparser import allowed_parsers as parsers
 
-
-__version__ = '1.3.3'
+__version__ = VERSION
 
 # the original property-function is overwritten
 # so get it back!

--- a/odml/__init__.py
+++ b/odml/__init__.py
@@ -8,7 +8,7 @@ from .fileio import load, save, display
 from .tools.odmlparser import allowed_parsers as parsers
 
 
-__version__ = '1.3.2'
+__version__ = '1.3.3'
 
 # the original property-function is overwritten
 # so get it back!

--- a/odml/fileio.py
+++ b/odml/fileio.py
@@ -1,6 +1,6 @@
-from .tools.odmlparser import ODMLReader, ODMLWriter
+from .tools.odmlparser import ODMLReader, ODMLWriter, allowed_parsers
 
-parsers = ["xml", "json", "yaml"]
+PARSERS = allowed_parsers
 
 
 def load(filename, backend="xml"):

--- a/odml/fileio.py
+++ b/odml/fileio.py
@@ -4,15 +4,38 @@ PARSERS = allowed_parsers
 
 
 def load(filename, backend="xml"):
+    """
+    Load an odML document from file.
+    :param filename: Path and filename from where the odML document
+                     is to be loaded and parsed.
+    :param backend: File format of the file containing the odML document.
+                    The default format is XML.
+    :return: The parsed odML document.
+    """
     reader = ODMLReader(backend)
     return reader.from_file(filename)
 
 
 def save(obj, filename, backend="xml"):
+    """
+    Save an open odML document to file of a specified format.
+    :param obj: odML document do be saved.
+    :param filename: Filename and path where the odML document
+                     should be saved.
+    :param backend: Format in which the odML document is to be saved.
+                    The default format is XML.
+    """
     writer = ODMLWriter(backend)
     return writer.write_file(obj, filename)
 
 
 def display(obj, backend="xml"):
+    """
+    Print an open odML document to the command line, formatted in the
+    specified format.
+    :param obj: odML document to be displayed.
+    :param backend: Format in which the odML document is to be displayed.
+                    The default format is XML.
+    """
     writer = ODMLWriter(backend)
     print(writer.to_string(obj))

--- a/odml/info.py
+++ b/odml/info.py
@@ -1,0 +1,2 @@
+VERSION = '1.3.3'
+FORMAT_VERSION = '1'

--- a/odml/info.py
+++ b/odml/info.py
@@ -1,2 +1,15 @@
 VERSION = '1.3.3'
 FORMAT_VERSION = '1'
+AUTHOR = 'Hagen Fritsch, Christian Kellner, Jan Grewe, ' \
+          'Achilleas Koutsou, Michael Sonntag, Lyuba Zehl'
+COPYRIGHT = '(c) 2011-2017, German Neuroinformatics Node'
+CONTACT = 'dev@g-node.org'
+HOMEPAGE = 'https://github.com/G-Node/python-odml'
+CLASSIFIERS = [
+    'Programming Language :: Python :: 2',
+    'Programming Language :: Python :: 3',
+    'License :: OSI Approved :: BSD License',
+    'Development Status :: 5 - Production/Stable',
+    'Topic :: Scientific/Engineering',
+    'Intended Audience :: Science/Research'
+]

--- a/odml/section.py
+++ b/odml/section.py
@@ -25,12 +25,17 @@ class BaseSection(base.sectionable, mapping.mapableSection, Section):
 
     _format = format.Section
 
-    def __init__(self, name, type="undefined", parent=None, definition=None, mapping=None):
+    def __init__(self, name, type="undefined", parent=None, definition=None,
+                 mapping=None, reference=None, repository=None, link=None, include=None):
         self._parent = parent
         self._name = name
         self._props = base.SmartList()
         self._definition = definition
         self._mapping = mapping
+        self._reference = reference
+        self._repository = repository
+        self._link = link
+        self._include = include
         super(BaseSection, self).__init__()
         # this may fire a change event, so have the section setup then
         self.type = type

--- a/odml/tools/odmlparser.py
+++ b/odml/tools/odmlparser.py
@@ -150,8 +150,8 @@ class ODMLReader:
     based on the given data exchange format, like XML, YAML or JSON.
 
     Usage:
-        yaml_odml_doc = ODMLReader(parser='YAML').fromFile(open("odml_doc.yaml"))
-        json_odml_doc = ODMLReader(parser='JSON').fromFile(open("odml_doc.json"))
+        yaml_odml_doc = ODMLReader(parser='YAML').from_file("odml_doc.yaml")
+        json_odml_doc = ODMLReader(parser='JSON').from_file("odml_doc.json")
     """
 
     def __init__(self, parser='XML'):
@@ -266,13 +266,13 @@ class ODMLReader:
             return odml_doc
 
         elif self.parser == 'YAML':
-            try:
-                self.parsed_doc = yaml.load(file)
-            except yaml.parser.ParserError as e:
-                print(e)
-                return
-            finally:
-                file.close()
+            with open(file) as yaml_data:
+                try:
+                    self.parsed_doc = yaml.load(yaml_data)
+                except yaml.parser.ParserError as e:
+                    print(e)
+                    return
+
             return self.to_odml()
 
         elif self.parser == 'JSON':

--- a/odml/tools/odmlparser.py
+++ b/odml/tools/odmlparser.py
@@ -277,7 +277,7 @@ class ODMLReader:
     def from_file(self, file):
 
         if self.parser == 'XML' or self.parser == 'ODML':
-            odml_doc = xmlparser.XMLReader().fromFile(file)
+            odml_doc = xmlparser.XMLReader(ignore_errors=True).fromFile(file)
             self.doc = odml_doc
             return odml_doc
 

--- a/odml/tools/odmlparser.py
+++ b/odml/tools/odmlparser.py
@@ -9,12 +9,10 @@ Parses odML files and documents.
 
 import json
 import yaml
-from .. import format
-from . import xmlparser
 
-# FIX ME: Version should not be hardcoded here. Import from odML module after
-#         fixing the circular imports issue.
-odml_version = '1'
+from .. import format
+from ..info import FORMAT_VERSION
+from . import xmlparser
 
 allowed_parsers = ['ODML', 'XML', 'YAML', 'JSON']
 
@@ -133,7 +131,7 @@ class ODMLWriter:
             self.to_dict(odml_document)
             odml_output = {}
             odml_output['Document'] = self.parsed_doc
-            odml_output['odml-version'] = odml_version
+            odml_output['odml-version'] = FORMAT_VERSION
 
             if self.parser == 'YAML':
                 string_doc = yaml.dump(odml_output, default_flow_style=False)
@@ -170,7 +168,7 @@ class ODMLReader:
         return None
 
     def to_odml(self):
-        self.odml_version = self.parsed_doc.get('odml-version', odml_version)
+        self.odml_version = self.parsed_doc.get('odml-version', FORMAT_VERSION)
         self.parsed_doc = self.parsed_doc['Document']
 
         doc_attrs = {}

--- a/odml/tools/odmlparser.py
+++ b/odml/tools/odmlparser.py
@@ -173,13 +173,16 @@ class ODMLReader:
         if parser not in allowed_parsers:
             raise NotImplementedError("'%s' odML parser does not exist!" % parser)
         self.parser = parser
+        self.warnings = []
 
     def is_valid_attribute(self, attr, fmt):
         if attr in fmt._args:
             return attr
         if fmt.revmap(attr):
             return attr
-        print("Invalid element <%s> inside <%s> tag" % (attr, fmt.__class__.__name__))
+        msg = "Invalid element <%s> inside <%s> tag" % (attr, fmt.__class__.__name__)
+        print(msg)
+        self.warnings.append(msg)
         return None
 
     def to_odml(self):
@@ -277,7 +280,9 @@ class ODMLReader:
     def from_file(self, file):
 
         if self.parser == 'XML' or self.parser == 'ODML':
-            odml_doc = xmlparser.XMLReader(ignore_errors=True).fromFile(file)
+            par = xmlparser.XMLReader(ignore_errors=True)
+            self.warnings = par.warnings
+            odml_doc = par.fromFile(file)
             self.doc = odml_doc
             return odml_doc
 

--- a/odml/tools/odmlparser.py
+++ b/odml/tools/odmlparser.py
@@ -7,8 +7,8 @@ Parses odML files and documents.
 
 """
 
-import yaml
 import json
+import yaml
 from .. import format
 from . import xmlparser
 
@@ -20,13 +20,13 @@ allowed_parsers = ['ODML', 'XML', 'YAML', 'JSON']
 
 
 class ODMLWriter:
-    '''
+    """
         A generic odML document writer, for XML, YAML and JSON.
 
         Usage:
             xml_writer = ODMLWriter(parser='XML')
             xml_writer.write_file(odml_document, filepath)
-    '''
+    """
 
     def __init__(self, parser='XML'):
         self.doc = None  # odML document
@@ -55,7 +55,6 @@ class ODMLWriter:
         self.parsed_doc = parsed_doc
 
     def get_sections(self, section_list):
-
         section_seq = []
 
         for section in section_list:
@@ -81,7 +80,6 @@ class ODMLWriter:
         return section_seq
 
     def get_properties(self, props_list):
-
         props_seq = []
 
         for prop in props_list:
@@ -100,7 +98,7 @@ class ODMLWriter:
                             prop_dict[attr] = t
 
             props_seq.append(prop_dict)
-        
+
         return props_seq
 
     def get_values(self, value_list):
@@ -172,7 +170,6 @@ class ODMLReader:
         return None
 
     def to_odml(self):
-
         self.odml_version = self.parsed_doc.get('odml-version', odml_version)
         self.parsed_doc = self.parsed_doc['Document']
 
@@ -193,7 +190,6 @@ class ODMLReader:
         return self.doc
 
     def parse_sections(self, section_list):
-        
         odml_sections = []
 
         for section in section_list:
@@ -217,7 +213,6 @@ class ODMLReader:
             odml_sections.append(sec)
 
         return odml_sections
-
 
     def parse_properties(self, props_list):
         odml_props = []
@@ -257,7 +252,6 @@ class ODMLReader:
 
         return odml_values
 
-
     def from_file(self, file):
 
         if self.parser == 'XML' or self.parser == 'ODML':
@@ -284,7 +278,6 @@ class ODMLReader:
                     return
 
             return self.to_odml()
-
 
     def from_string(self, string):
 

--- a/odml/tools/odmlparser.py
+++ b/odml/tools/odmlparser.py
@@ -17,6 +17,10 @@ from . import xmlparser
 allowed_parsers = ['ODML', 'XML', 'YAML', 'JSON']
 
 
+class ParserException(Exception):
+    pass
+
+
 class ODMLWriter:
     """
         A generic odML document writer, for XML, YAML and JSON.
@@ -168,7 +172,16 @@ class ODMLReader:
         return None
 
     def to_odml(self):
-        self.odml_version = self.parsed_doc.get('odml-version', FORMAT_VERSION)
+        # Parse only odML documents of supported format versions.
+        if 'odml-version' not in self.parsed_doc:
+            raise ParserException("Invalid odML document: Could not find odml-version.")
+        elif self.parsed_doc.get('odml-version') != FORMAT_VERSION:
+            msg = ("Invalid odML document format version '%s'. "
+                   "Supported versions: '%s'."
+                   % (self.parsed_doc.get('odml-version'), FORMAT_VERSION))
+            raise ParserException(msg)
+
+        self.odml_version = self.parsed_doc.get('odml-version')
         self.parsed_doc = self.parsed_doc['Document']
 
         doc_attrs = {}

--- a/odml/tools/odmlparser.py
+++ b/odml/tools/odmlparser.py
@@ -292,17 +292,19 @@ class ODMLReader:
             odml_doc = xmlparser.XMLReader().fromString(string)
             self.doc = odml_doc
             return self.doc
+
         elif self.parser == 'YAML':
             try:
-                odml_doc = yaml.load(string)
+                self.parsed_doc = yaml.load(string)
             except yaml.parser.ParserError as e:
                 print(e)
                 return
             return self.to_odml()
+
         elif self.parser == 'JSON':
             try:
-                odml_doc = json.loads(string)
-            except json.decoder.JSONDecodeError as e:
-                print(e)
+                self.parsed_doc = json.loads(string)
+            except ValueError as e:  # Python 2 does not support JSONDecodeError
+                print("JSON Decoder Error: %s" % e)
                 return
             return self.to_odml()

--- a/odml/tools/odmlparser.py
+++ b/odml/tools/odmlparser.py
@@ -276,13 +276,13 @@ class ODMLReader:
             return self.to_odml()
 
         elif self.parser == 'JSON':
-            try:
-                self.parsed_doc = json.load(file)
-            except json.decoder.JSONDecodeError as e:
-                print(e)
-                return
-            finally:
-                file.close()
+            with open(file) as json_data:
+                try:
+                    self.parsed_doc = json.load(json_data)
+                except ValueError as e:  # Python 2 does not support JSONDecodeError
+                    print("JSON Decoder Error: %s" % e)
+                    return
+
             return self.to_odml()
 
 

--- a/odml/tools/odmlparser.py
+++ b/odml/tools/odmlparser.py
@@ -122,6 +122,17 @@ class ODMLWriter:
         return value_seq
 
     def write_file(self, odml_document, filename):
+        # Write document only if it does not contain validation errors.
+        from ..validation import Validation  # disgusting import problems
+        validation = Validation(odml_document)
+        msg = ""
+        for e in validation.errors:
+            if e.is_error:
+                msg += "\n\t- %s %s: %s" % (e.obj, e.type, e.msg)
+        if msg != "":
+            msg = "Resolve document validation errors before saving %s" % msg
+            raise ParserException(msg)
+
         file = open(filename, 'w')
         file.write(self.to_string(odml_document))
         file.close()

--- a/odml/tools/odmlparser.py
+++ b/odml/tools/odmlparser.py
@@ -190,8 +190,8 @@ class ODMLReader:
         if 'odml-version' not in self.parsed_doc:
             raise ParserException("Invalid odML document: Could not find odml-version.")
         elif self.parsed_doc.get('odml-version') != FORMAT_VERSION:
-            msg = ("Invalid odML document format version '%s'. "
-                   "Supported versions: '%s'."
+            msg = ("Cannot read file: invalid odML document format version '%s'. \n"
+                   "This package supports odML format versions: '%s'."
                    % (self.parsed_doc.get('odml-version'), FORMAT_VERSION))
             raise ParserException(msg)
 

--- a/odml/tools/xmlparser.py
+++ b/odml/tools/xmlparser.py
@@ -13,6 +13,7 @@ from lxml import etree as ET
 from lxml.builder import E
 # this is needed for py2exe to include lxml completely
 from lxml import _elementpath as _dummy
+from ..info import FORMAT_VERSION
 
 try:
     unicode = unicode
@@ -34,8 +35,6 @@ format.Section._xml_attributes = {'name': None}  # attribute 'name' maps to 'nam
 format.Property._xml_attributes = {}
 format.Value._xml_attributes = {}
 format.Value._xml_content = 'value'
-
-XML_VERSION = "1"
 
 
 class XMLWriter:
@@ -66,7 +65,7 @@ class XMLWriter:
 
         # generate attributes
         if isinstance(fmt, format.Document.__class__):
-            cur.attrib['version'] = XML_VERSION
+            cur.attrib['version'] = FORMAT_VERSION
 
         for k, v in fmt._xml_attributes.items():
             if not v or not hasattr(e, fmt.map(v)):

--- a/odml/tools/xmlparser.py
+++ b/odml/tools/xmlparser.py
@@ -6,7 +6,6 @@ Parses odML files. Can be invoked standalone:
 
     python -m odml.tools.xmlparser file.odml
 """
-#TODO make this module a parser class, allow arguments (e.g. skip_errors=1 to parse even broken documents)
 import sys
 from odml import format
 from lxml import etree as ET
@@ -148,6 +147,7 @@ class XMLReader(object):
         self.tags = dict([(obj._xml_name, obj) for obj in format.__all__])
         self.ignore_errors = ignore_errors
         self.filename = filename
+        self.warnings = []
 
     @staticmethod
     def _handle_version(root):
@@ -212,6 +212,7 @@ class XMLReader(object):
             msg = "warning[%s:%d:<%s>]: %s\n" % (self.filename, elem.sourceline, elem.tag, msg)
         else:
             msg = "warning: %s\n" % msg
+        self.warnings.append(msg)
         sys.stderr.write(msg)
 
     def parse_element(self, node):

--- a/odml/tools/xmlparser.py
+++ b/odml/tools/xmlparser.py
@@ -149,6 +149,26 @@ class XMLReader(object):
         self.ignore_errors = ignore_errors
         self.filename = filename
 
+    @staticmethod
+    def _handle_version(root):
+        """
+        Check if the odML version of a handed in parsed lxml.etree is supported
+        by the current library and raise an Exception otherwise.
+        :param root: Root node of a parsed lxml.etree. Teh root tag has to
+                     contain a supported odML version number, otherwise it is not
+                     accepted as a valid odML file.
+        """
+        if root.tag != 'odML':
+            raise ParserException("Expecting <odML> start tag but got <%s>.\n" % root.tag)
+        elif 'version' not in root.attrib:
+            raise ParserException("Could not find format version attribute "
+                                  "in odML start tag.\n")
+        elif root.attrib['version'] != FORMAT_VERSION:
+            msg = ("Invalid odML document format version '%s'. "
+                   "Supported versions: '%s'."
+                   % (root.attrib['version'], FORMAT_VERSION))
+            raise ParserException(msg)
+
     def fromFile(self, xml_file):
         """
         parse the datastream from a file like object *xml_file*
@@ -158,6 +178,8 @@ class XMLReader(object):
             root = ET.parse(xml_file, self.parser).getroot()
         except ET.XMLSyntaxError as e:
             raise ParserException(e.msg)
+
+        self._handle_version(root)
         return self.parse_element(root)
 
     def fromString(self, string):
@@ -165,6 +187,8 @@ class XMLReader(object):
             root = ET.XML(string, self.parser)
         except ET.XMLSyntaxError as e:
             raise ParserException(e.msg)
+
+        self._handle_version(root)
         return self.parse_element(root)
 
     def check_mandatory_arguments(self, data, ArgClass, tag_name, node):

--- a/odml/tools/xmlparser.py
+++ b/odml/tools/xmlparser.py
@@ -164,8 +164,8 @@ class XMLReader(object):
             raise ParserException("Could not find format version attribute "
                                   "in odML start tag.\n")
         elif root.attrib['version'] != FORMAT_VERSION:
-            msg = ("Invalid odML document format version '%s'. "
-                   "Supported versions: '%s'."
+            msg = ("Cannot read file: invalid odML document format version '%s'. \n"
+                   "This package supports odML format versions: '%s'."
                    % (root.attrib['version'], FORMAT_VERSION))
             raise ParserException(msg)
 

--- a/odml/tools/xmlparser.py
+++ b/odml/tools/xmlparser.py
@@ -154,15 +154,15 @@ class XMLReader(object):
         """
         Check if the odML version of a handed in parsed lxml.etree is supported
         by the current library and raise an Exception otherwise.
-        :param root: Root node of a parsed lxml.etree. Teh root tag has to
+        :param root: Root node of a parsed lxml.etree. The root tag has to
                      contain a supported odML version number, otherwise it is not
                      accepted as a valid odML file.
         """
         if root.tag != 'odML':
-            raise ParserException("Expecting <odML> start tag but got <%s>.\n" % root.tag)
+            raise ParserException("Expecting <odML> tag but got <%s>.\n" % root.tag)
         elif 'version' not in root.attrib:
             raise ParserException("Could not find format version attribute "
-                                  "in odML start tag.\n")
+                                  "in <odML> tag.\n")
         elif root.attrib['version'] != FORMAT_VERSION:
             msg = ("Cannot read file: invalid odML document format version '%s'. \n"
                    "This package supports odML format versions: '%s'."

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ try:
     from setuptools import setup
 except ImportError as ex:
     from distutils.core import setup
+from odml.info import AUTHOR, CONTACT, CLASSIFIERS, HOMEPAGE, VERSION
 
 packages = [
     'odml',
@@ -12,19 +13,24 @@ packages = [
 with open('README.rst') as f:
     description_text = f.read()
 
+with open("LICENSE") as f:
+    license_text = f.read()
+
 install_req = ["lxml", "pyyaml"]
 if sys.version_info < (3, 4):
     install_req += ["enum34"]
 
 setup(
     name='odML',
-    version='1.3.2',
+    version=VERSION,
     description='open metadata Markup Language',
-    author='G-Node',
-    author_email='dev@g-node.org',
-    url='http://www.g-node.org/projects/odml',
+    author=AUTHOR,
+    author_email=CONTACT,
+    url=HOMEPAGE,
     packages=packages,
     test_suite='test',
     install_requires=install_req,
     long_description=description_text,
+    classifiers=CLASSIFIERS,
+    license=license_text
 )

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -38,14 +38,14 @@ class TestParser(unittest.TestCase):
     def test_xml(self):
 
         self.xml_writer.write_file(self.odml_doc, self.xml_file)
-        xml_doc = self.xml_reader.from_file(open(self.xml_file))
+        xml_doc = self.xml_reader.from_file(self.xml_file)
 
         self.assertEqual(xml_doc, self.odml_doc)
 
     def test_yaml(self):
 
         self.yaml_writer.write_file(self.odml_doc, self.yaml_file)
-        yaml_doc = self.yaml_reader.from_file(open(self.yaml_file))
+        yaml_doc = self.yaml_reader.from_file(self.yaml_file)
 
         self.assertEqual(yaml_doc, self.odml_doc)
 
@@ -53,7 +53,7 @@ class TestParser(unittest.TestCase):
     def test_json(self):
 
         self.json_writer.write_file(self.odml_doc, self.json_file)
-        json_doc = self.json_reader.from_file(open(self.json_file))
+        json_doc = self.json_reader.from_file(self.json_file)
 
         self.assertEqual(json_doc, self.odml_doc)
 
@@ -61,13 +61,13 @@ class TestParser(unittest.TestCase):
     def test_json_yaml_xml(self):
 
         self.json_writer.write_file(self.odml_doc, self.json_file)
-        json_doc = self.json_reader.from_file(open(self.json_file))
+        json_doc = self.json_reader.from_file(self.json_file)
         
         self.yaml_writer.write_file(json_doc, self.yaml_file)
-        yaml_doc = self.yaml_reader.from_file(open(self.yaml_file))
+        yaml_doc = self.yaml_reader.from_file(self.yaml_file)
 
         self.xml_writer.write_file(yaml_doc, self.xml_file)
-        xml_doc = self.xml_reader.from_file(open(self.xml_file))
+        xml_doc = self.xml_reader.from_file(self.xml_file)
 
         self.assertEqual(json_doc, self.odml_doc)
         self.assertEqual(json_doc, yaml_doc)

--- a/test/test_samplefile.py
+++ b/test/test_samplefile.py
@@ -5,6 +5,7 @@ import os
 import sys
 import re
 
+from odml.info import FORMAT_VERSION
 from odml.tools import xmlparser
 from odml.tools import jsonparser
 from odml.tools import dumper
@@ -141,10 +142,10 @@ class SampleFileOperationTest(unittest.TestCase):
             val = unicode(xmlparser.XMLWriter(doc))
         else:
             val = str(xmlparser.XMLWriter(doc))
-        self.assertIn('version="%s"' % xmlparser.XML_VERSION, val)
+        self.assertIn('version="%s"' % FORMAT_VERSION, val)
         doc = xmlparser.XMLReader().fromString(val)
         # this test is switched off until the XML versioning support is implemented
-        # self.assertEqual(doc._xml_version, xmlparser.XML_VERSION)
+        # self.assertEqual(doc._xml_version, FORMAT_VERSION)
 
     def test_save(self):
         for module in [xmlparser.XMLWriter, jsonparser.JSONWriter]:


### PR DESCRIPTION
This PR introduces the following changes to the 1.3 branch:
- [Doc format] Provides a package and a document format version number in the new file `info.py`
- [Doc format] All parsers now use the common document format version number.
- [Doc format] When trying to open a file with any of the odml parsers, first the document format version number is checked. If the found version number does not match the supported one, file loading will fail an exception, since this is the oldest format version. If anyone tries to open a newer format, they should first update their odml package and not use this one...
- [Doc saving] An odML document can now only be saved, if the validation does not show any errors. Saving an invalid document will exit while printing all encountered errors.
- [Parser loading] All parsers are now more relaxed when encountering unsupported tags or missing tags and only print warnings instead of ending with an exception. Warnings are collected and can be accessed via the parser object (required for display in odml-ui to avoid potential loss of information).
- [Setup] now contains updated authors, contact, website, license and classifiers.
- Cherry picks from the development branch to address #191 and #194 also in the 1.3 branch.
