### PR TITLE
[1.4] Version handling, parser fixes, setup update, fix terminology load

### DIFF
--- a/odml/__init__.py
+++ b/odml/__init__.py
@@ -5,9 +5,10 @@ from . import property
 from . import section
 from .dtypes import DType
 from .fileio import load, save, display
+from .info import VERSION
 from .tools.odmlparser import allowed_parsers as parsers
 
-__version__ = '1.4.0'
+__version__ = VERSION
 
 
 class odml_implementation(object):

--- a/odml/__init__.py
+++ b/odml/__init__.py
@@ -7,7 +7,7 @@ from .dtypes import DType
 from .fileio import load, save, display
 from .tools.odmlparser import allowed_parsers as parsers
 
-__version__ = '1.3.dev0'
+__version__ = '1.4.0'
 
 
 class odml_implementation(object):

--- a/odml/fileio.py
+++ b/odml/fileio.py
@@ -5,15 +5,32 @@ PARSERS = allowed_parsers
 
 
 def load(filename, backend="xml"):
+    """
+    Load an odML document from file.
+    :param filename: Path and filename from where the odML document
+                     is to be loaded and parsed.
+    :param backend: File format of the file containing the odML document.
+                    The default format is XML.
+    :return: The parsed odML document.
+    """
     if not os.path.exists(filename):
         msg = "File \'%s\' was not found!" % \
               (filename if len(filename) < 20 else "...%s" % filename[19:])
         raise FileNotFoundError(msg)
+
     reader = ODMLReader(backend)
     return reader.from_file(filename)
 
 
 def save(obj, filename, backend="xml"):
+    """
+    Save an open odML document to file of a specified format.
+    :param obj: odML document do be saved.
+    :param filename: Filename and path where the odML document
+                     should be saved.
+    :param backend: Format in which the odML document is to be saved.
+                    The default format is XML.
+    """
     writer = ODMLWriter(backend)
     if "." not in filename.split(os.pathsep)[-1]:
         filename = filename + ".%s" % backend
@@ -21,5 +38,12 @@ def save(obj, filename, backend="xml"):
 
 
 def display(obj, backend="xml"):
+    """
+    Print an open odML document to the command line, formatted in the
+    specified format.
+    :param obj: odML document to be displayed.
+    :param backend: Format in which the odML document is to be displayed.
+                    The default format is XML.
+    """
     writer = ODMLWriter(backend)
     print(writer.to_string(obj))

--- a/odml/fileio.py
+++ b/odml/fileio.py
@@ -1,12 +1,14 @@
 import os
-from .tools.odmlparser import ODMLReader, ODMLWriter
+from .tools.odmlparser import ODMLReader, ODMLWriter, allowed_parsers
 
-parsers = ["xml", "json", "yaml"]
+PARSERS = allowed_parsers
 
 
 def load(filename, backend="xml"):
     if not os.path.exists(filename):
-        raise FileNotFoundError("File \'%s\' was not found!" % (filename if len(filename) < 20 else "...%s" % filename[19:]))
+        msg = "File \'%s\' was not found!" % \
+              (filename if len(filename) < 20 else "...%s" % filename[19:])
+        raise FileNotFoundError(msg)
     reader = ODMLReader(backend)
     return reader.from_file(filename)
 

--- a/odml/info.py
+++ b/odml/info.py
@@ -1,2 +1,15 @@
 VERSION = '1.4.0'
 FORMAT_VERSION = '1.1'
+AUTHOR = 'Hagen Fritsch, Christian Kellner, Jan Grewe, ' \
+          'Achilleas Koutsou, Michael Sonntag, Lyuba Zehl'
+COPYRIGHT = '(c) 2011-2017, German Neuroinformatics Node'
+CONTACT = 'dev@g-node.org'
+HOMEPAGE = 'https://github.com/G-Node/python-odml'
+CLASSIFIERS = [
+    'Programming Language :: Python :: 2',
+    'Programming Language :: Python :: 3',
+    'License :: OSI Approved :: BSD License',
+    'Development Status :: 5 - Production/Stable',
+    'Topic :: Scientific/Engineering',
+    'Intended Audience :: Science/Research'
+]

--- a/odml/info.py
+++ b/odml/info.py
@@ -1,0 +1,2 @@
+VERSION = '1.4.0'
+FORMAT_VERSION = '1.1'

--- a/odml/terminology.py
+++ b/odml/terminology.py
@@ -78,7 +78,7 @@ class Terminologies(dict):
             return
         try:
             term = odml.tools.xmlparser.XMLReader(
-                filename=url, ignore_errors=True).fromFile(fp)
+                filename=url, ignore_errors=True).from_file(fp)
             term.finalize()
         except odml.tools.xmlparser.ParserException as e:
             print("Failed to load %s due to parser errors" % url)

--- a/odml/terminology.py
+++ b/odml/terminology.py
@@ -7,12 +7,14 @@ import os
 import tempfile
 import datetime
 import odml.tools.xmlparser
+import sys
+import threading
+
 from hashlib import md5
 try:
     import urllib.request as urllib2
 except ImportError:
     import urllib2
-import threading
 
 
 CACHE_AGE = datetime.timedelta(days=1)
@@ -37,6 +39,8 @@ def cache_load(url):
        datetime.datetime.now() - CACHE_AGE:
         try:
             data = urllib2.urlopen(url).read()
+            if sys.version_info.major > 2:
+                data = data.decode("utf-8")
         except Exception as e:
             print("failed loading '%s': %s" % (url, e))
             return

--- a/odml/tools/odmlparser.py
+++ b/odml/tools/odmlparser.py
@@ -151,13 +151,16 @@ class ODMLReader:
         if parser not in allowed_parsers:
             raise NotImplementedError("'%s' odML parser does not exist!" % parser)
         self.parser = parser
+        self.warnings = []
 
     def is_valid_attribute(self, attr, fmt):
         if attr in fmt._args:
             return attr
         if fmt.revmap(attr):
             return attr
-        print("Invalid element <%s> inside <%s> tag" % (attr, fmt.__class__.__name__))
+        msg = "Invalid element <%s> inside <%s> tag" % (attr, fmt.__class__.__name__)
+        print(msg)
+        self.warnings.append(msg)
         return None
 
     def to_odml(self):
@@ -237,7 +240,9 @@ class ODMLReader:
     def from_file(self, file):
 
         if self.parser == 'XML':
-            odml_doc = xmlparser.XMLReader(ignore_errors=True).fromFile(file)
+            par = xmlparser.XMLReader(ignore_errors=True)
+            self.warnings = par.warnings
+            odml_doc = par.fromFile(file)
             self.doc = odml_doc
             return odml_doc
 

--- a/odml/tools/odmlparser.py
+++ b/odml/tools/odmlparser.py
@@ -237,7 +237,7 @@ class ODMLReader:
     def from_file(self, file):
 
         if self.parser == 'XML':
-            odml_doc = xmlparser.XMLReader().fromFile(file)
+            odml_doc = xmlparser.XMLReader(ignore_errors=True).fromFile(file)
             self.doc = odml_doc
             return odml_doc
 

--- a/odml/tools/odmlparser.py
+++ b/odml/tools/odmlparser.py
@@ -100,6 +100,17 @@ class ODMLWriter:
         return props_seq
 
     def write_file(self, odml_document, filename):
+        # Write document only if it does not contain validation errors.
+        from ..validation import Validation  # disgusting import problems
+        validation = Validation(odml_document)
+        msg = ""
+        for e in validation.errors:
+            if e.is_error:
+                msg += "\n\t- %s %s: %s" % (e.obj, e.type, e.msg)
+        if msg != "":
+            msg = "Resolve document validation errors before saving %s" % msg
+            raise ParserException(msg)
+
         file = open(filename, 'w')
         file.write(self.to_string(odml_document))
         file.close()

--- a/odml/tools/odmlparser.py
+++ b/odml/tools/odmlparser.py
@@ -17,6 +17,10 @@ from . import xmlparser
 allowed_parsers = ['XML', 'YAML', 'JSON']
 
 
+class ParserException(Exception):
+    pass
+
+
 class ODMLWriter:
     """
         A generic odML document writer, for XML, YAML and JSON.
@@ -146,7 +150,16 @@ class ODMLReader:
         return None
 
     def to_odml(self):
-        self.odml_version = self.parsed_doc.get('odml-version', FORMAT_VERSION)
+        # Parse only odML documents of supported format versions.
+        if 'odml-version' not in self.parsed_doc:
+            raise ParserException("Invalid odML document: Could not find odml-version.")
+        elif self.parsed_doc.get('odml-version') != FORMAT_VERSION:
+            msg = ("Invalid odML document format version '%s'. "
+                   "Supported versions: '%s'."
+                   % (self.parsed_doc.get('odml-version'), FORMAT_VERSION))
+            raise ParserException(msg)
+
+        self.odml_version = self.parsed_doc.get('odml-version')
         self.parsed_doc = self.parsed_doc['Document']
 
         doc_attrs = {}

--- a/odml/tools/odmlparser.py
+++ b/odml/tools/odmlparser.py
@@ -168,8 +168,8 @@ class ODMLReader:
         if 'odml-version' not in self.parsed_doc:
             raise ParserException("Invalid odML document: Could not find odml-version.")
         elif self.parsed_doc.get('odml-version') != FORMAT_VERSION:
-            msg = ("Invalid odML document format version '%s'. "
-                   "Supported versions: '%s'."
+            msg = ("Cannot read file: invalid odML document format version '%s'. \n"
+                   "This package supports odML format versions: '%s'."
                    % (self.parsed_doc.get('odml-version'), FORMAT_VERSION))
             raise ParserException(msg)
 

--- a/odml/tools/odmlparser.py
+++ b/odml/tools/odmlparser.py
@@ -242,7 +242,7 @@ class ODMLReader:
         if self.parser == 'XML':
             par = xmlparser.XMLReader(ignore_errors=True)
             self.warnings = par.warnings
-            odml_doc = par.fromFile(file)
+            odml_doc = par.from_file(file)
             self.doc = odml_doc
             return odml_doc
 
@@ -269,7 +269,7 @@ class ODMLReader:
     def from_string(self, string):
 
         if self.parser == 'XML':
-            odml_doc = xmlparser.XMLReader().fromString(string)
+            odml_doc = xmlparser.XMLReader().from_string(string)
             self.doc = odml_doc
             return self.doc
 

--- a/odml/tools/odmlparser.py
+++ b/odml/tools/odmlparser.py
@@ -9,12 +9,10 @@ Parses odML files and documents.
 
 import json
 import yaml
-from .. import format
-from . import xmlparser
 
-# FIX ME: Version should not be hardcoded here. Import from odML module after
-#         fixing the circular imports issue.
-odml_version = '1.1'
+from .. import format
+from ..info import FORMAT_VERSION
+from . import xmlparser
 
 allowed_parsers = ['XML', 'YAML', 'JSON']
 
@@ -111,7 +109,7 @@ class ODMLWriter:
             self.to_dict(odml_document)
             odml_output = {}
             odml_output['Document'] = self.parsed_doc
-            odml_output['odml-version'] = odml_version
+            odml_output['odml-version'] = FORMAT_VERSION
 
             if self.parser == 'YAML':
                 string_doc = yaml.dump(odml_output, default_flow_style=False)
@@ -148,7 +146,7 @@ class ODMLReader:
         return None
 
     def to_odml(self):
-        self.odml_version = self.parsed_doc['odml-version']
+        self.odml_version = self.parsed_doc.get('odml-version', FORMAT_VERSION)
         self.parsed_doc = self.parsed_doc['Document']
 
         doc_attrs = {}

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -4,7 +4,7 @@ import sys
 
 from lxml import etree as ET
 from .. import format
-from odml.tools.xmlparser import XML_VERSION
+from odml.tools.odmlparser import FORMAT_VERSION
 
 try:
     unicode = unicode
@@ -53,7 +53,7 @@ class VersionConverter(object):
 
         tree = cls._replace_same_name_entities(tree)
         root = tree.getroot()
-        root.set("version", XML_VERSION)
+        root.set("version", FORMAT_VERSION)
 
         rem_property = []
         for prop in root.iter("property"):

--- a/odml/tools/xmlparser.py
+++ b/odml/tools/xmlparser.py
@@ -19,6 +19,7 @@ from lxml import etree as ET
 from lxml.builder import E
 # this is needed for py2exe to include lxml completely
 from lxml import _elementpath as _dummy
+from ..info import FORMAT_VERSION
 
 try:
     unicode = unicode
@@ -34,8 +35,6 @@ format.Document._xml_attributes = {}
 # attribute 'name' maps to 'name', but writing it as a tag is preferred
 format.Section._xml_attributes = {'name': None}
 format.Property._xml_attributes = {}
-
-XML_VERSION = "1.1"
 
 
 def to_csv(val):
@@ -88,7 +87,7 @@ class XMLWriter:
 
         # generate attributes
         if isinstance(fmt, format.Document.__class__):
-            cur.attrib['version'] = XML_VERSION
+            cur.attrib['version'] = FORMAT_VERSION
 
         for k, v in fmt._xml_attributes.items():
             if not v or not hasattr(e, fmt.map(v)):

--- a/odml/tools/xmlparser.py
+++ b/odml/tools/xmlparser.py
@@ -6,8 +6,6 @@ Parses odML files. Can be invoked standalone:
 
     python -m odml.tools.xmlparser file.odml
 """
-# TODO make this module a parser class, allow arguments (e.g.
-# skip_errors=1 to parse even broken documents)
 import sys
 import csv
 try:
@@ -175,6 +173,7 @@ class XMLReader(object):
         self.tags = dict([(obj._xml_name, obj) for obj in format.__all__])
         self.ignore_errors = ignore_errors
         self.filename = filename
+        self.warnings = []
 
     @staticmethod
     def _handle_version(root):
@@ -245,6 +244,7 @@ class XMLReader(object):
                 self.filename, elem.sourceline, elem.tag, msg)
         else:
             msg = "warning: %s\n" % msg
+        self.warnings.append(msg)
         sys.stderr.write(msg)
 
     def parse_element(self, node):

--- a/odml/tools/xmlparser.py
+++ b/odml/tools/xmlparser.py
@@ -150,9 +150,9 @@ class XMLWriter:
 
 def load(filename):
     """
-    shortcut function for XMLReader().fromFile(open(filename))
+    shortcut function for XMLReader().from_file(filename)
     """
-    return XMLReader().fromFile(open(filename))
+    return XMLReader().from_file(filename)
 
 
 class ParserException(Exception):
@@ -165,7 +165,7 @@ class XMLReader(object):
 
     Usage:
 
-        >>> doc = XMLReader().fromFile(open("file.odml"))
+        >>> doc = XMLReader().from_file("file.odml")
     """
 
     def __init__(self, ignore_errors=False, filename=None):
@@ -195,7 +195,7 @@ class XMLReader(object):
                    % (root.attrib['version'], FORMAT_VERSION))
             raise ParserException(msg)
 
-    def fromFile(self, xml_file):
+    def from_file(self, xml_file):
         """
         parse the datastream from a file like object *xml_file*
         and return an odml data structure
@@ -210,7 +210,7 @@ class XMLReader(object):
         self._handle_version(root)
         return self.parse_element(root)
 
-    def fromString(self, string):
+    def from_string(self, string):
         try:
             root = ET.XML(string, self.parser)
         except ET.XMLSyntaxError as e:

--- a/odml/tools/xmlparser.py
+++ b/odml/tools/xmlparser.py
@@ -190,8 +190,8 @@ class XMLReader(object):
             raise ParserException("Could not find format version attribute "
                                   "in odML start tag.\n")
         elif root.attrib['version'] != FORMAT_VERSION:
-            msg = ("Invalid odML document format version '%s'. "
-                   "Supported versions: '%s'."
+            msg = ("Cannot read file: invalid odML document format version '%s'. \n"
+                   "This package supports odML format versions: '%s'."
                    % (root.attrib['version'], FORMAT_VERSION))
             raise ParserException(msg)
 

--- a/odml/tools/xmlparser.py
+++ b/odml/tools/xmlparser.py
@@ -180,15 +180,15 @@ class XMLReader(object):
         """
         Check if the odML version of a handed in parsed lxml.etree is supported
         by the current library and raise an Exception otherwise.
-        :param root: Root node of a parsed lxml.etree. Teh root tag has to
+        :param root: Root node of a parsed lxml.etree. The root tag has to
                      contain a supported odML version number, otherwise it is not
                      accepted as a valid odML file.
         """
         if root.tag != 'odML':
-            raise ParserException("Expecting <odML> start tag but got <%s>.\n" % root.tag)
+            raise ParserException("Expecting <odML> tag but got <%s>.\n" % root.tag)
         elif 'version' not in root.attrib:
             raise ParserException("Could not find format version attribute "
-                                  "in odML start tag.\n")
+                                  "in <odML> tag.\n")
         elif root.attrib['version'] != FORMAT_VERSION:
             msg = ("Cannot read file: invalid odML document format version '%s'. \n"
                    "This package supports odML format versions: '%s'."

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,7 @@ try:
     from setuptools import setup
 except ImportError as ex:
     from distutils.core import setup
-
-from odml import __version__
+from odml.info import AUTHOR, CONTACT, CLASSIFIERS, HOMEPAGE, VERSION
 
 packages = [
     'odml',
@@ -14,18 +13,24 @@ packages = [
 with open('README.rst') as f:
     description_text = f.read()
 
+with open("LICENSE") as f:
+    license_text = f.read()
+
 install_req = ["lxml", "pyyaml"]
 if sys.version_info < (3, 4):
     install_req += ["enum34"]
 
-setup(name='odML',
-      version=__version__,
-      description='open metadata Markup Language',
-      author='Hagen Fritsch',
-      author_email='fritsch+gnode@in.tum.de',
-      url='http://www.g-node.org/projects/odml',
-      packages=packages,
-      test_suite='test',
-      install_requires=install_req,
-      long_description=description_text,
-      )
+setup(
+    name='odML',
+    version=VERSION,
+    description='open metadata Markup Language',
+    author=AUTHOR,
+    author_email=CONTACT,
+    url=HOMEPAGE,
+    packages=packages,
+    test_suite='test',
+    install_requires=install_req,
+    long_description=description_text,
+    classifiers=CLASSIFIERS,
+    license=license_text
+)

--- a/test/test_infer_type.py
+++ b/test/test_infer_type.py
@@ -73,7 +73,7 @@ class TestInferType(unittest.TestCase):
             str_doc = unicode(XMLWriter(doc))
         else:
             str_doc = str(XMLWriter(doc))
-        new_doc = XMLReader().fromString(str_doc)
+        new_doc = XMLReader().from_string(str_doc)
         new_sec = new_doc.sections[0]
 
         p = new_sec.properties["strprop"]

--- a/test/test_samplefile.py
+++ b/test/test_samplefile.py
@@ -145,7 +145,7 @@ class SampleFileOperationTest(unittest.TestCase):
         else:
             val = str(xmlparser.XMLWriter(doc))
         self.assertIn('version="%s"' % FORMAT_VERSION, val)
-        doc = xmlparser.XMLReader().fromString(val)
+        doc = xmlparser.XMLReader().from_string(val)
         # This test is switched off until the XML versioning support is implemented
         # self.assertEqual(doc._xml_version, FORMAT_VERSION)
 
@@ -174,7 +174,7 @@ class SampleFileOperationTest(unittest.TestCase):
                 doc = StringIO(unicode(doc))
             else:
                 doc = StringIO(str(doc))
-            doc = Reader().fromFile(doc)
+            doc = Reader().from_file(doc)
             self.assertEqual(doc, self.doc)
 
 #        for a,b in zip(doc.sections, self.doc.sections):

--- a/test/test_samplefile.py
+++ b/test/test_samplefile.py
@@ -5,6 +5,7 @@ import os
 import sys
 import re
 
+from odml.info import FORMAT_VERSION
 from odml.tools import xmlparser
 from odml.tools import jsonparser
 from odml.tools import dumper
@@ -143,11 +144,10 @@ class SampleFileOperationTest(unittest.TestCase):
             val = unicode(xmlparser.XMLWriter(doc))
         else:
             val = str(xmlparser.XMLWriter(doc))
-        self.assertIn('version="%s"' % xmlparser.XML_VERSION, val)
+        self.assertIn('version="%s"' % FORMAT_VERSION, val)
         doc = xmlparser.XMLReader().fromString(val)
-        # The following test is switched off until the XML versioning
-        # support is implemented.
-        # self.assertEqual(doc._xml_version, xmlparser.XML_VERSION)
+        # This test is switched off until the XML versioning support is implemented
+        # self.assertEqual(doc._xml_version, FORMAT_VERSION)
 
     def test_save(self):
         for module in [xmlparser.XMLWriter]:  # , jsonparser.JSONWriter]:


### PR DESCRIPTION
This PR is mainly cherry picking and refactoring of [1.3] PR #197.

It additionally:
- Changes the version number to 1.4.0.
- Fixes a terminology loading decode error when using python 3.
- Refactors `XMLReader.fromString` and `.fromFile` to snake case.