### PR TITLE
Final fixes for release 1.3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,23 +4,26 @@ dist: trusty
 language: python
 
 matrix:
-    include:
-        - os: linux
-          python: "2.7"
-          env: COVERALLS=1
-        - os: linux
-          python: "3.4"
-        - os: linux
-          python: "3.5"
+  include:
+    - os: linux
+      python: "2.7"
+      env: COVERALLS=1
+    - os: linux
+      python: "3.4"
+    - os: linux
+      python: "3.5"
 
-        - os: osx
-          language: generic
-          env:
-            - OSXENV=2.7
-        - os: osx
-          language: generic
-          env:
-            - OSXENV=3.5
+    - os: osx
+      language: generic
+      env:
+        - OSXENV=3.5
+#    Keep only one osx branch active for now
+#    since currently osx builds on travis
+#    are frequently stalled or indefinitely delayed.
+#    - os: osx
+#      language: generic
+#      env:
+#        - OSXENV=2.7
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then bash resources/install_osx_virtualenv.sh; fi

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,12 @@
-odML libraries and editor
-=========================
 .. image:: https://travis-ci.org/G-Node/python-odml.svg?branch=master
     :target: https://travis-ci.org/G-Node/python-odml
+.. image:: https://ci.appveyor.com/api/projects/status/2wfvsu7boe18kwjy?svg=true
+    :target: https://ci.appveyor.com/project/mpsonntag/python-odml
 .. image:: https://coveralls.io/repos/github/G-Node/python-odml/badge.svg?branch=master
     :target: https://coveralls.io/github/G-Node/python-odml?branch=master
+
+odML libraries and editor
+=========================
 
 Dependencies
 ------------

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,6 @@ packages = [
 with open('README.rst') as f:
     description_text = f.read()
 
-with open("LICENSE") as f:
-    license_text = f.read()
-
 install_req = ["lxml", "pyyaml"]
 if sys.version_info < (3, 4):
     install_req += ["enum34"]
@@ -32,5 +29,5 @@ setup(
     install_requires=install_req,
     long_description=description_text,
     classifiers=CLASSIFIERS,
-    license=license_text
+    license="BSD"
 )


### PR DESCRIPTION
This adorable PR
- removes the license text from setup.py. The license text interfered with the PyPI process in a way, that the description was not displayed on PyPI. With this setup it works fine.
- osx builds on travis currently take quite some time until they start. Therefore the osx builds are reduced to one until further notice.

Once this PR has been merged and the package tested on testpypi.python.org, we can do the v1.3.3 release on PyPI proper.