### PR TITLE
[1.4] Small fixes and CI updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,23 +4,26 @@ dist: trusty
 language: python
 
 matrix:
-    include:
-        - os: linux
-          python: "2.7"
-          env: COVERALLS=1
-        - os: linux
-          python: "3.4"
-        - os: linux
-          python: "3.5"
+  include:
+    - os: linux
+      python: "2.7"
+      env: COVERALLS=1
+    - os: linux
+      python: "3.4"
+    - os: linux
+      python: "3.5"
 
-        - os: osx
-          language: generic
-          env:
-            - OSXENV=2.7
-        - os: osx
-          language: generic
-          env:
-            - OSXENV=3.5
+    - os: osx
+      language: generic
+      env:
+        - OSXENV=3.5
+#    Keep only one osx branch active for now
+#    since currently osx builds on travis
+#    are frequently stalled or indefinitely delayed.
+#    - os: osx
+#      language: generic
+#      env:
+#        - OSXENV=2.7
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then bash resources/install_osx_virtualenv.sh; fi

--- a/README.rst
+++ b/README.rst
@@ -1,14 +1,17 @@
-odML libraries and editor
-=========================
 .. image:: https://travis-ci.org/G-Node/python-odml.svg?branch=master
     :target: https://travis-ci.org/G-Node/python-odml
+.. image:: https://ci.appveyor.com/api/projects/status/2wfvsu7boe18kwjy?svg=true
+    :target: https://ci.appveyor.com/project/mpsonntag/python-odml
 .. image:: https://coveralls.io/repos/github/G-Node/python-odml/badge.svg?branch=master
     :target: https://coveralls.io/github/G-Node/python-odml?branch=master
+
+odML libraries and editor
+=========================
 
 The Python-odML library (including the odML-Editor) is available on
 `GitHub <https://github.com/G-Node/python-odml>`_. If you are not familiar with
 the version control system **git**, but still want to use it, have a look at
-the documentaion available on the `git-scm website <https://git-scm.com/>`_.
+the documentation available on the `git-scm website <https://git-scm.com/>`_.
 
 Dependencies
 ------------

--- a/odml/property.py
+++ b/odml/property.py
@@ -171,7 +171,8 @@ class BaseProperty(base.baseobject, Property):
 
     @value.setter
     def value(self, new_value):
-        if not new_value:
+        # Make sure boolean value 'False' gets through as well...
+        if new_value is None or new_value == "":
             return
         if isinstance(new_value, str):
             if new_value[0] == "[" and new_value[-1] == "]":

--- a/odml/property.py
+++ b/odml/property.py
@@ -171,15 +171,13 @@ class BaseProperty(base.baseobject, Property):
 
     @value.setter
     def value(self, new_value):
-        if new_value is None:
+        if not new_value:
             return
         if isinstance(new_value, str):
             if new_value[0] == "[" and new_value[-1] == "]":
                 new_value = new_value[1:-1].split(",")
         if not isinstance(new_value, list):
             new_value = [new_value]
-        if len(new_value) == 0:
-            return
         if self._dtype is None:
             self._dtype = dtypes.infer_dtype(new_value[0])
         if not self._validate_values(new_value):

--- a/odml/terminology.py
+++ b/odml/terminology.py
@@ -17,7 +17,7 @@ except ImportError:
     import urllib2
 
 
-REPOSITORY = 'http://portal.g-node.org/odml/terminologies/v1.0/terminologies.xml'
+REPOSITORY = 'http://portal.g-node.org/odml/terminologies/v1.1/terminologies.xml'
 
 CACHE_AGE = datetime.timedelta(days=1)
 

--- a/odml/terminology.py
+++ b/odml/terminology.py
@@ -17,6 +17,8 @@ except ImportError:
     import urllib2
 
 
+REPOSITORY = 'http://portal.g-node.org/odml/terminologies/v1.0/terminologies.xml'
+
 CACHE_AGE = datetime.timedelta(days=1)
 
 
@@ -96,11 +98,11 @@ class Terminologies(dict):
         self.loading[url] = threading.Thread(target=self._load, args=(url,))
         self.loading[url].start()
 
+
 terminologies = Terminologies()
 load = terminologies.load
 deferred_load = terminologies.deferred_load
 
 
 if __name__ == "__main__":
-    f = cache_load('http://portal.g-node.org/odml/terminologies/v1.0/'
-                   'analysis/analysis.xml')
+    f = cache_load(REPOSITORY)

--- a/odml/tools/xmlparser.py
+++ b/odml/tools/xmlparser.py
@@ -50,6 +50,8 @@ def from_csv(value_string):
         return []
     if value_string[0] == "[":
         value_string = value_string[1:-1]
+    if not value_string:
+        return []
     stream = StringIO(value_string)
     stream.seek(0)
     reader = csv.reader(stream, dialect="excel")

--- a/odml/tools/xmlparser.py
+++ b/odml/tools/xmlparser.py
@@ -46,10 +46,10 @@ def to_csv(val):
 
 
 def from_csv(value_string):
+    if not value_string:
+        return []
     if value_string[0] == "[":
         value_string = value_string[1:-1]
-    if len(value_string) == 0:
-        return []
     stream = StringIO(value_string)
     stream.seek(0)
     reader = csv.reader(stream, dialect="excel")
@@ -292,13 +292,13 @@ class XMLReader(object):
                         self.warn("Element <%s> is given multiple times in "
                                   "<%s> tag" % (node.tag, root.tag), node)
 
-                    # Special handling of values
-                    if tag == "value" and node.text:
-                        content = from_csv(node.text.strip())
+                    # Special handling of values;
+                    curr_text = node.text.strip() if node.text else None
+                    if tag == "value" and curr_text:
+                        content = from_csv(node.text)
                         arguments[tag] = content
                     else:
-                        arguments[tag] = node.text.strip(
-                        ) if node.text else None
+                        arguments[tag] = curr_text
             else:
                 self.error("Invalid element <%s> in odML document section <%s>"
                            % (node.tag, root.tag), node)

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,6 @@ packages = [
 with open('README.rst') as f:
     description_text = f.read()
 
-with open("LICENSE") as f:
-    license_text = f.read()
-
 install_req = ["lxml", "pyyaml", "rdflib", "rdflib-jsonld"]
 
 if sys.version_info < (3, 4):
@@ -34,5 +31,5 @@ setup(
     install_requires=install_req,
     long_description=description_text,
     classifiers=CLASSIFIERS,
-    license=license_text
+    license="BSD"
 )

--- a/test/test_bugs.py
+++ b/test/test_bugs.py
@@ -1,14 +1,14 @@
 import odml
 import unittest
 
+from odml.terminology import REPOSITORY
+
 
 class BugTests(unittest.TestCase):
 
     def test_doc_repository_attribute_init(self):
-        repo = "http://portal.g-node.org/odml/terminologies/v1.0/" \
-               "terminologies.xml"
-        doc = odml.Document(repository=repo)
-        self.assertEqual(doc._repository, repo,
+        doc = odml.Document(repository=REPOSITORY)
+        self.assertEqual(doc._repository, REPOSITORY,
                          "Document needs to init its baseclass first, "
                          "as it overwrites the repository attribute")
-        self.assertEqual(doc.repository, repo)
+        self.assertEqual(doc.repository, REPOSITORY)


### PR DESCRIPTION
This PR
- removes the license text from setup.py. The license text interfered with the PyPI process in a way, that the description was not displayed on PyPI. With this setup it works fine.
- osx builds on travis currently take quite some time until they start. Therefore the osx builds are reduced to one until further notice.
- resolves #205 and #206 to fix potential broken terminology loading/parsing.
- adds and uses a default terminology repository: http://portal.g-node.org/odml/terminologies/v1.1/terminologies.xml.
