### PR TITLE
Local install and py2 boolean conversion fix

### DIFF
--- a/odml/dtypes.py
+++ b/odml/dtypes.py
@@ -196,7 +196,7 @@ def datetime_set(value):
 def boolean_get(string):
     if string is None:
         return None
-    if isinstance(string, unicode):
+    if type(string) in (unicode, str):
         string = string.lower()
     truth = ["true", "1", True, "t"]  # be kind, spec only accepts True / False
     if string in truth:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,25 @@ try:
     from setuptools import setup
 except ImportError as ex:
     from distutils.core import setup
-from odml.info import AUTHOR, CONTACT, CLASSIFIERS, HOMEPAGE, VERSION
+
+try:
+    from odml.info import AUTHOR, CONTACT, CLASSIFIERS, HOMEPAGE, VERSION
+except ImportError as ex:
+    # Read the information from odml.info.py if package dependencies
+    # are not yet available during a local install.
+    CLASSIFIERS = ""
+    with open('odml/info.py') as f:
+        for line in f:
+            curr_args = line.split(" = ")
+            if len(curr_args) == 2:
+                if curr_args[0] == "AUTHOR":
+                    AUTHOR = curr_args[1].replace('\'', '').replace('\\', '').strip()
+                elif curr_args[0] == "CONTACT":
+                    CONTACT = curr_args[1].replace('\'', '').strip()
+                elif curr_args[0] == "HOMEPAGE":
+                    HOMEPAGE = curr_args[1].replace('\'', '').strip()
+                elif curr_args[0] == "VERSION":
+                    VERSION = curr_args[1].replace('\'', '').strip()
 
 packages = [
     'odml',


### PR DESCRIPTION
This tiny PR fixes
- a bug in `setup.py` which prohibits local install if the dependencies are not already installed.
- closes #222; boolean false values depending on lower case string conversion are now properly converted to False in python 2 as well.