### PR TITLE
Refactor package info handling

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE
 include README.rst
+include odml/info.json

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
 include LICENSE
 include README.rst
-include odml.desktop

--- a/README.rst
+++ b/README.rst
@@ -21,13 +21,20 @@ Dependencies
 
   * enum (version 0.4.4)
   * lxml (version 3.7.2)
+  * yaml (version 3.12)
+  * rdflib (version >=4.2.2)
 
-* These packages will be downloaded and installed automatically if the :code:`pip` method is used to install odML. Alternatively, they can be installed from the OS package manager. On Ubuntu, they are available as:
+* These packages will be downloaded and installed automatically if the :code:`pip`
+  method is used to install odML. Alternatively, they can be installed from the OS
+  package manager. On Ubuntu, they are available as:
 
   * python-enum
   * python-lxml
+  * python-yaml
+  * python-rdflib
 
-* If you prefer installing using the Python package manager, the following packages are required to build the lxml Python package on Ubuntu 14.04:
+* If you prefer installing using the Python package manager, the following packages are
+  required to build the lxml Python package on Ubuntu 14.04:
 
   * libxml2-dev
   * libxslt1-dev
@@ -43,7 +50,8 @@ The simplest way to install Python-odML is from PyPI using the pip tool::
 
 On Ubuntu, the pip package manager is available in the repositories as :code:`python-pip`.
 
-If this method is used, the appropriate Python dependencies (enum and lxml) are downloaded and installed automatically.
+If this method is used, the appropriate Python dependencies are downloaded and installed
+automatically.
 
 
 Building from source
@@ -63,7 +71,8 @@ To install the Python-odML library, enter the corresponding directory and run::
   $ cd python-odml
   $ python setup.py install
 
-**Note** The master branch is our current development branch, not all features might be working as expected. Use the release tags instead.
+**Note** The master branch is our current development branch, not all features might be
+working as expected. Use the release tags instead.
 
 Documentation
 -------------
@@ -76,4 +85,6 @@ Bugs & Questions
 Should you find a behaviour that is likely a bug, please file a bug report at
 `the github bug tracker <https://github.com/G-Node/python-odml/issues>`_.
 
-If you have questions regarding the use of the library or the editor, feel free to join the `#gnode <http://webchat.freenode.net?channels=%23gnode>`_ IRC channel on freenode.
+If you have questions regarding the use of the library or the editor, feel free to
+join the `#gnode <http://webchat.freenode.net?channels=%23gnode>`_ IRC channel
+on freenode.

--- a/odml/dtypes.py
+++ b/odml/dtypes.py
@@ -204,8 +204,8 @@ def boolean_get(string):
     false = ["false", "0", False, "f"]
     if string in false:
         return False
-    return bool(string)
-
+    # disallow any values that cannot be interpreted as boolean.
+    raise ValueError
 
 # Alias boolean_set to boolean_get. Both perform same function.
 

--- a/odml/info.json
+++ b/odml/info.json
@@ -1,0 +1,16 @@
+{
+  "VERSION": "1.4.0",
+  "FORMAT_VERSION": "1.1",
+  "AUTHOR": "Hagen Fritsch, Christian Kellner, Jan Grewe, Achilleas Koutsou, Michael Sonntag, Lyuba Zehl",
+  "COPYRIGHT": "(c) 2011-2017, German Neuroinformatics Node",
+  "CONTACT": "dev@g-node.org",
+  "HOMEPAGE": "https://github.com/G-Node/python-odml",
+  "CLASSIFIERS": [
+    "Programming Language :: Python :: 2",
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: BSD License",
+    "Development Status :: 5 - Production/Stable",
+    "Topic :: Scientific/Engineering",
+    "Intended Audience :: Science/Research"
+  ]
+}

--- a/odml/info.py
+++ b/odml/info.py
@@ -1,15 +1,15 @@
-VERSION = '1.4.0'
-FORMAT_VERSION = '1.1'
-AUTHOR = 'Hagen Fritsch, Christian Kellner, Jan Grewe, ' \
-          'Achilleas Koutsou, Michael Sonntag, Lyuba Zehl'
-COPYRIGHT = '(c) 2011-2017, German Neuroinformatics Node'
-CONTACT = 'dev@g-node.org'
-HOMEPAGE = 'https://github.com/G-Node/python-odml'
-CLASSIFIERS = [
-    'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 3',
-    'License :: OSI Approved :: BSD License',
-    'Development Status :: 5 - Production/Stable',
-    'Topic :: Scientific/Engineering',
-    'Intended Audience :: Science/Research'
-]
+import os
+import json
+
+here = os.path.dirname(__file__)
+
+with open(os.path.join(here, "info.json")) as infofile:
+    infodict = json.load(infofile)
+
+VERSION = infodict["VERSION"]
+FORMAT_VERSION = infodict["FORMAT_VERSION"]
+AUTHOR = infodict["AUTHOR"]
+COPYRIGHT = infodict["COPYRIGHT"]
+CONTACT = infodict["CONTACT"]
+HOMEPAGE = infodict["HOMEPAGE"]
+CLASSIFIERS = infodict["CLASSIFIERS"]

--- a/odml/tools/dict_parser.py
+++ b/odml/tools/dict_parser.py
@@ -114,7 +114,10 @@ class DictReader:
         self.parsed_doc = parsed_doc
 
         # Parse only odML documents of supported format versions.
-        if 'odml-version' not in self.parsed_doc:
+        if 'Document' not in self.parsed_doc:
+            msg = "Missing root element 'Document'"
+            raise ParserException(msg)
+        elif 'odml-version' not in self.parsed_doc:
             raise ParserException("Invalid odML document: Could not find odml-version.")
 
         elif self.parsed_doc.get('odml-version') != FORMAT_VERSION:

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+import json
+import os
 import sys
 
 try:
@@ -5,24 +7,17 @@ try:
 except ImportError as ex:
     from distutils.core import setup
 
-try:
-    from odml.info import AUTHOR, CONTACT, CLASSIFIERS, HOMEPAGE, VERSION
-except ImportError as ex:
-    # Read the information from odml.info.py if package dependencies
-    # are not yet available during a local install.
-    CLASSIFIERS = ""
-    with open('odml/info.py') as f:
-        for line in f:
-            curr_args = line.split(" = ")
-            if len(curr_args) == 2:
-                if curr_args[0] == "AUTHOR":
-                    AUTHOR = curr_args[1].replace('\'', '').replace('\\', '').strip()
-                elif curr_args[0] == "CONTACT":
-                    CONTACT = curr_args[1].replace('\'', '').strip()
-                elif curr_args[0] == "HOMEPAGE":
-                    HOMEPAGE = curr_args[1].replace('\'', '').strip()
-                elif curr_args[0] == "VERSION":
-                    VERSION = curr_args[1].replace('\'', '').strip()
+with open(os.path.join("odml/info.json")) as infofile:
+    infodict = json.load(infofile)
+
+VERSION = infodict["VERSION"]
+FORMAT_VERSION = infodict["FORMAT_VERSION"]
+AUTHOR = infodict["AUTHOR"]
+COPYRIGHT = infodict["COPYRIGHT"]
+CONTACT = infodict["CONTACT"]
+HOMEPAGE = infodict["HOMEPAGE"]
+CLASSIFIERS = infodict["CLASSIFIERS"]
+
 
 packages = [
     'odml',
@@ -47,6 +42,7 @@ setup(
     packages=packages,
     test_suite='test',
     install_requires=install_req,
+    include_package_data=True,
     long_description=description_text,
     classifiers=CLASSIFIERS,
     license="BSD"

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ packages = [
 with open('README.rst') as f:
     description_text = f.read()
 
-install_req = ["lxml", "pyyaml", "rdflib", "rdflib-jsonld"]
+install_req = ["lxml", "pyyaml", "rdflib"]
 
 if sys.version_info < (3, 4):
     install_req += ["enum34"]

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ try:
 except ImportError as ex:
     from distutils.core import setup
 
-with open(os.path.join("odml/info.json")) as infofile:
+with open(os.path.join("odml", "info.json")) as infofile:
     infodict = json.load(infofile)
 
 VERSION = infodict["VERSION"]

--- a/test/resources/invalid_root.xml
+++ b/test/resources/invalid_root.xml
@@ -1,0 +1,5 @@
+<invalid>
+  <date>2018-02-27</date>
+  <version>1.0</version>
+  <author>Test author</author>
+</invalid>

--- a/test/resources/invalid_version.json
+++ b/test/resources/invalid_version.json
@@ -1,0 +1,9 @@
+{
+    "odml-version": "invalid",
+    "Document": {
+        "date": "2018-02-27",
+        "version": "1.0",
+        "sections": [],
+        "author": "Test author"
+    }
+}

--- a/test/resources/invalid_version.xml
+++ b/test/resources/invalid_version.xml
@@ -1,0 +1,5 @@
+<odML version="invalid">
+  <date>2018-02-27</date>
+  <version>1.0</version>
+  <author>Test author</author>
+</odML>

--- a/test/resources/invalid_version.yaml
+++ b/test/resources/invalid_version.yaml
@@ -1,0 +1,6 @@
+Document:
+  author: Test author
+  date: '2018-02-27'
+  sections: []
+  version: '1.0'
+odml-version: 'totallyUnsupported'

--- a/test/resources/missing_root.json
+++ b/test/resources/missing_root.json
@@ -1,0 +1,6 @@
+{
+    "odml-version": "1.1",
+    "sometag": {
+      "Document": "somecontent"
+    }
+}

--- a/test/resources/missing_root.yaml
+++ b/test/resources/missing_root.yaml
@@ -1,0 +1,2 @@
+Root:
+  some: value

--- a/test/resources/missing_version.json
+++ b/test/resources/missing_version.json
@@ -1,0 +1,8 @@
+{
+    "Document": {
+        "date": "2018-02-27",
+        "version": "1.0",
+        "sections": [],
+        "author": "Test author"
+    }
+}

--- a/test/resources/missing_version.xml
+++ b/test/resources/missing_version.xml
@@ -1,0 +1,5 @@
+<odML>
+  <date>2018-02-27</date>
+  <version>1.0</version>
+  <author>Test author</author>
+</odML>

--- a/test/resources/missing_version.yaml
+++ b/test/resources/missing_version.yaml
@@ -1,0 +1,5 @@
+Document:
+  author: Test author
+  date: '2018-02-27'
+  sections: []
+  version: '1.0'

--- a/test/test_dtypes.py
+++ b/test/test_dtypes.py
@@ -45,6 +45,24 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(s.value[0], 'Jerin')
         self.assertEqual(s.dtype, 'string')
 
+    def test_bool(self):
+        self.assertEqual(None, typ.boolean_get(None))
+
+        true_values = [True, "TRUE", "true", "T", "t", "1", 1]
+        for val in true_values:
+            self.assertTrue(typ.boolean_get(val))
+
+        false_values = [False, "FALSE", "false", "F", "f", "0", 0]
+        for val in false_values:
+            self.assertFalse(typ.boolean_get(val))
+
+        with self.assertRaises(ValueError):
+            typ.boolean_get("text")
+        with self.assertRaises(ValueError):
+            typ.boolean_get(12)
+        with self.assertRaises(ValueError):
+            typ.boolean_get(2.1)
+
     def test_tuple(self):
         # Success test
         t = odml.Property(name="Location", value='(39.12; 67.19)', dtype='2-tuple')

--- a/test/test_json_parser.py
+++ b/test/test_json_parser.py
@@ -1,0 +1,12 @@
+import unittest
+import os
+from odml.tools import dict_parser
+from odml.tools.parser_utils import ParserException
+
+
+class TestJSONParser(unittest.TestCase):
+
+    def setUp(self):
+        self.basepath = 'test/resources/'
+
+        self.json_reader = dict_parser.DictReader()

--- a/test/test_json_parser.py
+++ b/test/test_json_parser.py
@@ -1,5 +1,7 @@
-import unittest
+import json
 import os
+import unittest
+
 from odml.tools import dict_parser
 from odml.tools.parser_utils import ParserException
 
@@ -10,3 +12,39 @@ class TestJSONParser(unittest.TestCase):
         self.basepath = 'test/resources/'
 
         self.json_reader = dict_parser.DictReader()
+
+    def test_missing_root(self):
+        filename = "missing_root.json"
+        message = "Missing root element"
+
+        with open(os.path.join(self.basepath, filename)) as json_data:
+            parsed_doc = json.load(json_data)
+
+        with self.assertRaises(ParserException) as exc:
+            _ = self.json_reader.to_odml(parsed_doc)
+
+        self.assertIn(message, str(exc.exception))
+
+    def test_missing_version(self):
+        filename = "missing_version.json"
+        message = "Could not find odml-version"
+
+        with open(os.path.join(self.basepath, filename)) as json_data:
+            parsed_doc = json.load(json_data)
+
+        with self.assertRaises(ParserException) as exc:
+            _ = self.json_reader.to_odml(parsed_doc)
+
+        self.assertIn(message, str(exc.exception))
+
+    def test_invalid_version(self):
+        filename = "invalid_version.json"
+        message = "invalid odML document format version"
+
+        with open(os.path.join(self.basepath, filename)) as json_data:
+            parsed_doc = json.load(json_data)
+
+        with self.assertRaises(ParserException) as exc:
+            _ = self.json_reader.to_odml(parsed_doc)
+
+        self.assertIn(message, str(exc.exception))

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -16,18 +16,35 @@ class TestProperty(unittest.TestCase):
 
     def test_bool_conversion(self):
 
-        p = Property(name='received', value=[3, 0, 1, 0, 8])
+        # Success tests
+        p = Property(name='received', value=[1, 0, 1, 0, 1])
         assert(p.dtype == 'int')
         p.dtype = DType.boolean
         assert(p.dtype == 'boolean')
         assert(p.value == [True, False, True, False, True])
 
-        q = Property(name='sent',
-                     value=['False', True, 'TRUE', '0', 't', 'F', 'Ft'])
+        q = Property(name='sent', value=['False', True, 'TRUE', '0', 't', 'F', '1'])
         assert(q.dtype == 'string')
         q.dtype = DType.boolean
         assert(q.dtype == 'boolean')
         assert(q.value == [False, True, True, False, True, False, True])
+
+        # Failure tests
+        curr_val = [3, 0, 1, 0, 8]
+        curr_type = 'int'
+        p = Property(name='received', value=curr_val)
+        assert(p.dtype == curr_type)
+        with self.assertRaises(ValueError):
+            p.dtype = DType.boolean
+        assert(p.dtype == curr_type)
+        assert(p.value == curr_val)
+
+        curr_type = 'string'
+        q = Property(name='sent', value=['False', True, 'TRUE', '0', 't', '12', 'Ft'])
+        assert(q.dtype == curr_type)
+        with self.assertRaises(ValueError):
+            q.dtype = DType.boolean
+        assert(q.dtype == curr_type)
 
     def test_str_to_int_convert(self):
 

--- a/test/test_xml_parser.py
+++ b/test/test_xml_parser.py
@@ -1,0 +1,12 @@
+import unittest
+import os
+from odml.tools import xmlparser
+from odml.tools.parser_utils import ParserException
+
+
+class TestParser(unittest.TestCase):
+
+    def setUp(self):
+        self.basepath = 'test/resources/'
+
+        self.xml_reader = xmlparser.XMLReader()

--- a/test/test_xml_parser.py
+++ b/test/test_xml_parser.py
@@ -4,9 +4,27 @@ from odml.tools import xmlparser
 from odml.tools.parser_utils import ParserException
 
 
-class TestParser(unittest.TestCase):
+class TestXMLParser(unittest.TestCase):
 
     def setUp(self):
         self.basepath = 'test/resources/'
 
         self.xml_reader = xmlparser.XMLReader()
+
+    def test_invalid_root(self):
+        filename = "invalid_root.xml"
+
+        with self.assertRaises(ParserException):
+            _ = self.xml_reader.from_file(os.path.join(self.basepath, filename))
+
+    def test_missing_version(self):
+        filename = "missing_version.xml"
+
+        with self.assertRaises(ParserException):
+            _ = self.xml_reader.from_file(os.path.join(self.basepath, filename))
+
+    def test_invalid_version(self):
+        filename = "invalid_version.xml"
+
+        with self.assertRaises(ParserException):
+            _ = self.xml_reader.from_file(os.path.join(self.basepath, filename))

--- a/test/test_xml_parser.py
+++ b/test/test_xml_parser.py
@@ -1,5 +1,6 @@
-import unittest
 import os
+import unittest
+
 from odml.tools import xmlparser
 from odml.tools.parser_utils import ParserException
 
@@ -13,18 +14,27 @@ class TestXMLParser(unittest.TestCase):
 
     def test_invalid_root(self):
         filename = "invalid_root.xml"
+        message = "Expecting <odML>"
 
-        with self.assertRaises(ParserException):
+        with self.assertRaises(ParserException) as exc:
             _ = self.xml_reader.from_file(os.path.join(self.basepath, filename))
+
+        self.assertIn(message, str(exc.exception))
 
     def test_missing_version(self):
         filename = "missing_version.xml"
+        message = "Could not find format version attribute"
 
-        with self.assertRaises(ParserException):
+        with self.assertRaises(ParserException) as exc:
             _ = self.xml_reader.from_file(os.path.join(self.basepath, filename))
+
+        self.assertIn(message, str(exc.exception))
 
     def test_invalid_version(self):
         filename = "invalid_version.xml"
+        message = "invalid odML document format version"
 
-        with self.assertRaises(ParserException):
+        with self.assertRaises(ParserException) as exc:
             _ = self.xml_reader.from_file(os.path.join(self.basepath, filename))
+
+        self.assertIn(message, str(exc.exception))

--- a/test/test_yaml_parser.py
+++ b/test/test_yaml_parser.py
@@ -1,0 +1,14 @@
+import os
+import unittest
+import yaml
+
+from odml.tools import dict_parser
+from odml.tools.parser_utils import ParserException
+
+
+class TestYAMLParser(unittest.TestCase):
+
+    def setUp(self):
+        self.basepath = 'test/resources/'
+
+        self.yaml_reader = dict_parser.DictReader()

--- a/test/test_yaml_parser.py
+++ b/test/test_yaml_parser.py
@@ -12,3 +12,39 @@ class TestYAMLParser(unittest.TestCase):
         self.basepath = 'test/resources/'
 
         self.yaml_reader = dict_parser.DictReader()
+
+    def test_missing_root(self):
+        filename = "missing_root.yaml"
+        message = "Missing root element"
+
+        with open(os.path.join(self.basepath, filename)) as raw_data:
+            parsed_doc = yaml.load(raw_data)
+
+        with self.assertRaises(ParserException) as exc:
+            _ = self.yaml_reader.to_odml(parsed_doc)
+
+        self.assertIn(message, str(exc.exception))
+
+    def test_missing_version(self):
+        filename = "missing_version.yaml"
+        message = "Could not find odml-version"
+
+        with open(os.path.join(self.basepath, filename)) as raw_data:
+            parsed_doc = yaml.load(raw_data)
+
+        with self.assertRaises(ParserException) as exc:
+            _ = self.yaml_reader.to_odml(parsed_doc)
+
+        self.assertIn(message, str(exc.exception))
+
+    def test_invalid_version(self):
+        filename = "invalid_version.yaml"
+        message = "invalid odML document format version"
+
+        with open(os.path.join(self.basepath, filename)) as raw_data:
+            parsed_doc = yaml.load(raw_data)
+
+        with self.assertRaises(ParserException) as exc:
+            _ = self.yaml_reader.to_odml(parsed_doc)
+
+        self.assertIn(message, str(exc.exception))


### PR DESCRIPTION
This PR 
- fixes installation issues on "clean" systems: The way package information in `info.py` is imported into `setup.py` currently breaks any local install due to dependency issues on clean systems (which do not have dependencies already installed). Therefore the package information is moved to `info.json` and read in by both `info.py` and `setup.py`.
- Updates the `MANIFEST` by removing the obsolete desktop entry and adding the `info.json` file.
- fixes #224 by disallowing values that cannot be interpreted as boolean for a boolean DType.
- Removes the unused `rdflib-jsonld` dependency since 'python setup.py install' breaks on first
install if both `rdflib` and `rdflib-jsonld` are in the requirements for some non-obvious reason.
- Adds basic tests for xml-, json- and yamlparser as a first step to increase coverage on the parser side.