### PR TITLE
change value related behaviors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,6 @@ matrix:
 #      env:
 #        - OSXENV=2.7
 
-before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then bash resources/install_osx_virtualenv.sh; fi
-
 install:
   - export PYVER=${TRAVIS_PYTHON_VERSION:0:1}
   - if [ $PYVER = 3 ]; then
@@ -43,10 +40,18 @@ install:
     fi;
 
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      which $PYCMD;
-      source venv/bin/activate;
-      brew upgrade python;
-      which $PYCMD;
+      if [[ "$OSXENV" == "2.7" ]]; then
+        brew install python@2;
+        virtualenv venv -p python;
+        source venv/bin/activate;
+        export PYCMD=python;
+        export PIPCMD=pip;
+      else
+        brew upgrade python;
+        source venv/bin/activate;
+        export PYCMD=python3;
+        export PIPCMD=pip3;
+      fi;
     fi;
 
   - $PIPCMD install lxml enum34 pyyaml rdflib

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,23 +30,34 @@ before_install:
 
 install:
   - export PYVER=${TRAVIS_PYTHON_VERSION:0:1}
-  - if [ $COVERALLS = 1 ]; then
-        pip install --upgrade coveralls;
+  - if [ $PYVER = 3 ]; then
+      export PYCMD=python3;
+      export PIPCMD=pip3;
+    else
+      export PYCMD=python;
+      export PIPCMD=pip;
     fi;
+
+  - if [ $COVERALLS = 1 ]; then
+        $PIPCMD install --upgrade coveralls;
+    fi;
+
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      which python;
+      which $PYCMD;
       source venv/bin/activate;
-      which python;
-    fi
-  - pip install lxml enum34 pyyaml rdflib
+      brew upgrade python;
+      which $PYCMD;
+    fi;
+
+  - $PIPCMD install lxml enum34 pyyaml rdflib
 
 script:
-  - which python
-  - python setup.py build
+  - which $PYCMD
+  - $PYCMD setup.py build
   - if [ $COVERALLS = 1 ]; then
         coverage${PYVER} run --source=odml setup.py test && coverage${PYVER} report -m;
     else
-        python setup.py test;
+        $PYCMD setup.py test;
     fi;
 
 after_success:

--- a/odml/property.py
+++ b/odml/property.py
@@ -212,9 +212,17 @@ class BaseProperty(base.baseobject, Property):
         """
         if isinstance(new_value, str):
             if new_value[0] == "[" and new_value[-1] == "]":
-                new_value = new_value[1:-1].split(",")
-        if not isinstance(new_value, list):
+                new_value = list(map(str.strip, new_value[1:-1].split(",")))
+            else:
+                new_value = [new_value]
+        elif isinstance(new_value, dict):
+            new_value = [str(new_value)]
+        elif hasattr(new_value, '__iter__') or hasattr(new_value, '__next__'):
+            new_value = list(new_value)
+        elif not isinstance(new_value, list):
             new_value = [new_value]
+        else:
+            raise ValueError("odml.Property._convert_value_input: unsupported data type for values: %s" % type(new_value))
         return new_value
 
     @value.setter

--- a/odml/property.py
+++ b/odml/property.py
@@ -375,6 +375,16 @@ class BaseProperty(base.baseobject, Property):
     def __getitem__(self, key):
         return self._value[key]
 
+    def __setitem__(self, key, item):
+        if int(key) < 0 or int(key) > self.__len__():
+            raise IndexError("odml.Property.__setitem__: key %i invalid for array of length %i"
+                             % (int(key), self.__len__()))
+        try:
+            val = dtypes.get(item, self.dtype)
+            self._value[int(key)] = val
+        except Exception:
+            raise ValueError("odml.Property.__setitem__:  passed value cannot be converted to data type \'%s\'!" % self._dtype)
+
     def extend(self, obj):
         if isinstance(obj, BaseProperty):
             if (obj.unit != self.unit):

--- a/odml/property.py
+++ b/odml/property.py
@@ -286,9 +286,9 @@ class BaseProperty(base.baseobject, Property):
 
     def merge(self, property):
         """
-        Stub that doesn't do anything for this class
+        Merges the values in 'property' into self, if possible.
         """
-        pass
+        self.append(list(property.value))
 
     def unmerge(self, property):
         """
@@ -324,6 +324,9 @@ class BaseProperty(base.baseobject, Property):
         return self._value[key]
 
     def append(self, obj):
+        if isinstance(obj, BaseProperty):
+            self.merge(obj)
+            return
         if self._value == []:
             self.value = obj
         else:

--- a/odml/property.py
+++ b/odml/property.py
@@ -340,7 +340,7 @@ class BaseProperty(base.baseobject, Property):
             self.unit = other.unit
 
         to_add = [v for v in other.value if v not in self._value]
-        self.append(to_add)
+        self.extend(to_add)
 
     def unmerge(self, other):
         """
@@ -375,19 +375,33 @@ class BaseProperty(base.baseobject, Property):
     def __getitem__(self, key):
         return self._value[key]
 
-    def append(self, obj):
+    def extend(self, obj):
         if isinstance(obj, BaseProperty):
             if (obj.unit != self.unit):
                 raise ValueError("odml.Property.append: src and dest units (%s, %s) do not match!"
                                  % (obj.unit, self.unit))
-            self.append(list(obj.value))
+            self.extend(obj.value)
             return
-        if self._value == []:
+
+        if self.__len__() == 0:
+            self.value = obj
+            return
+
+        new_value = self._convert_value_input(obj)
+        if not self._validate_values(new_value):
+            raise ValueError("odml.Property.append: passed value(s) cannot be converted to "
+                             "data type \'%s\'!" % self._dtype)
+        self._value.extend([dtypes.get(v, self.dtype) for v in new_value])
+
+    def append(self, obj):
+        if isinstance(obj, (list)):
+            raise ValueError("odml.property.append: Use extend to add a list of values!")
+        if self.__len__() == 0:
             self.value = obj
         else:
             new_value = self._convert_value_input(obj)
             if not self._validate_values(new_value):
                 raise ValueError("odml.Property.append: passed value(s) cannot be converted to "
                                  "data type \'%s\'!" % self._dtype)
-            self._value.extend([dtypes.get(v, self.dtype) for v in new_value])
+            self._value.append(dtypes.get(new_value[0], self.dtype))
 

--- a/odml/property.py
+++ b/odml/property.py
@@ -461,14 +461,11 @@ class BaseProperty(base.baseobject, Property):
 
         :param obj the additional value.
         """
-        if isinstance(obj, (list)):
+        new_value = self._convert_value_input(obj)
+        if len(new_value) > 1:
             raise ValueError("odml.property.append: Use extend to add a list of values!")
-        if self.__len__() == 0:
-            self.value = obj
-        else:
-            new_value = self._convert_value_input(obj)
-            if not self._validate_values(new_value):
-                raise ValueError("odml.Property.append: passed value(s) cannot be converted to "
-                                 "data type \'%s\'!" % self._dtype)
-            self._value.append(dtypes.get(new_value[0], self.dtype))
+        if not self._validate_values(new_value):
+            raise ValueError("odml.Property.append: passed value(s) cannot be converted to "
+                             "data type \'%s\'!" % self._dtype)
+        self._value.append(dtypes.get(new_value[0], self.dtype))
 

--- a/odml/property.py
+++ b/odml/property.py
@@ -210,6 +210,8 @@ class BaseProperty(base.baseobject, Property):
 
     @value_origin.setter
     def value_origin(self, new_value):
+        if new_value == "":
+            new_value = None
         self._value_origin = new_value
 
     @property
@@ -226,6 +228,8 @@ class BaseProperty(base.baseobject, Property):
 
     @unit.setter
     def unit(self, new_value):
+        if new_value == "":
+            new_value = None
         self._unit = new_value
 
     @property
@@ -234,6 +238,8 @@ class BaseProperty(base.baseobject, Property):
 
     @reference.setter
     def reference(self, new_value):
+        if new_value == "":
+            new_value = None
         self._reference = new_value
 
     @property
@@ -242,6 +248,8 @@ class BaseProperty(base.baseobject, Property):
 
     @definition.setter
     def definition(self, new_value):
+        if new_value == "":
+            new_value = None
         self._definition = new_value
 
     @property
@@ -250,6 +258,8 @@ class BaseProperty(base.baseobject, Property):
 
     @dependency.setter
     def dependency(self, new_value):
+        if new_value == "":
+            new_value = None
         self._dependency = new_value
 
     @property
@@ -258,6 +268,8 @@ class BaseProperty(base.baseobject, Property):
 
     @dependency_value.setter
     def dependency_value(self, new_value):
+        if new_value == "":
+            new_value = None
         self._dependency_value = new_value
 
     def remove(self, value):

--- a/odml/property.py
+++ b/odml/property.py
@@ -326,7 +326,10 @@ class BaseProperty(base.baseobject, Property):
 
     def append(self, obj):
         if isinstance(obj, BaseProperty):
-            self.merge(obj)
+            if (obj.unit != self.unit):
+                raise ValueError("odml.Property.append: src and dest units (%s, %s) do not match!"
+                                 % (obj.unit, self.unit))
+            self.append(list(obj.value))
             return
         if self._value == []:
             self.value = obj

--- a/odml/property.py
+++ b/odml/property.py
@@ -287,17 +287,14 @@ class BaseProperty(base.baseobject, Property):
 
     def merge(self, other):
         """
-        Merges the values in 'other' into self, if possible.
+        Merges the property 'other' into self, if possible.
         """
         assert(isinstance(other, (BaseProperty)))
-        if self.unit is None and other.unit is not None:
-            self.unit = other.unit
-        if other.unit != self.unit:
+
+        if self.unit is not None and other.unit is not None and self.unit != other.unit:
             raise ValueError("odml.Property.merge: src and dest units (%s, %s) do not match!"
                              % (other.unit, self.unit))
 
-        if self.definition is None and other.definition is not None:
-            self.definition = other.definition
         if self.definition is not None and other.definition is not None:
             self_def = ''.join(map(str.strip, self.definition.split())).lower()
             other_def = ''.join(map(str.strip, other.definition.split())).lower()
@@ -306,14 +303,30 @@ class BaseProperty(base.baseobject, Property):
 
         if self.uncertainty is not None and other.uncertainty is not None:
             raise ValueError("odml.Property.merge: src and dest uncertainty both set and do not match!")
-        if self.uncertainty is None and other.uncertainty is not None:
-            self.uncertainty = other.uncertainty
 
         if self.reference is not None and other.reference is not None:
-            self_ref = ''.join(map(str.strip(), self.reference.lower().split()))
-            other_ref = ''.join(map(str.strip(), other.reference.lower().split()))
+            self_ref = ''.join(map(str.strip, self.reference.lower().split()))
+            other_ref = ''.join(map(str.strip, other.reference.lower().split()))
             if self_ref != other_ref:
-                raise ValueError("odml.Property.merge: src and dest references do not match!")
+                raise ValueError("odml.Property.merge: src and dest references are in conflict!")
+
+        if self.value_origin is not None and other.value_origin is not None:
+            self_ori = ''.join(map(str.strip, self.value_origin.lower().split()))
+            other_ori = ''.join(map(str.strip, other.value_origin.lower().split()))
+            if self_ori != other_ori:
+                raise ValueError("odml.Property.merge: src and dest value_origin are in conflict!")
+
+        if self.value_origin is None and other.value_origin is not None:
+            self.value_origin = other.value_origin
+        if self.uncertainty is None and other.uncertainty is not None:
+            self.uncertainty = other.uncertainty
+        if self.reference is None and other.reference is not None:
+            self.reference = other.reference
+        if self.definition is None and other.definition is not None:
+            self.definition = other.definition
+        if self.unit is None and other.unit is not None:
+            self.unit = other.unit
+
         to_add = [v for v in other.value if v not in self._value]
         self.append(to_add)
 

--- a/odml/property.py
+++ b/odml/property.py
@@ -172,18 +172,32 @@ class BaseProperty(base.baseobject, Property):
                 return False
         return True
 
-    @value.setter
-    def value(self, new_value):
-        # Make sure boolean value 'False' gets through as well...
-        if new_value is None or new_value == "":
-            return
+    def _convert_value_input(self, new_value):
+        """
+        This method ensures, that the passed new value is a list.
+        If new_value is a string, it will convert it to a list of
+        strings if the new_value contains embracing brackets.
+
+        returns list of new_value
+        """
         if isinstance(new_value, str):
             if new_value[0] == "[" and new_value[-1] == "]":
                 new_value = new_value[1:-1].split(",")
         if not isinstance(new_value, list):
             new_value = [new_value]
+        return new_value
+
+    @value.setter
+    def value(self, new_value):
+        # Make sure boolean value 'False' gets through as well...
+        if new_value is None or new_value == "":
+            return
+
+        new_value = self._convert_value_input(new_value)
+
         if self._dtype is None:
             self._dtype = dtypes.infer_dtype(new_value[0])
+
         if not self._validate_values(new_value):
             raise ValueError("odml.Property.value: passed values are not of "
                              "consistent type!")

--- a/odml/property.py
+++ b/odml/property.py
@@ -281,7 +281,7 @@ class BaseProperty(base.baseobject, Property):
         """
         obj = super(BaseProperty, self).clone()
         obj._section = None
-        obj.value = self.value
+        obj.value = self._value
         return obj
 
     def merge(self, property):

--- a/odml/property.py
+++ b/odml/property.py
@@ -395,7 +395,7 @@ class BaseProperty(base.baseobject, Property):
             self.unit = other.unit
 
         to_add = [v for v in other.value if v not in self._value]
-        self.extend(to_add)
+        self.extend(to_add, strict=strict)
 
     def unmerge(self, other):
         """

--- a/odml/property.py
+++ b/odml/property.py
@@ -150,7 +150,7 @@ class BaseProperty(base.baseobject, Property):
 
     @property
     def value(self):
-        return self._value
+        return tuple(self._value)
 
     def value_str(self, index=0):
         """

--- a/odml/property.py
+++ b/odml/property.py
@@ -285,13 +285,39 @@ class BaseProperty(base.baseobject, Property):
         obj.value = self._value
         return obj
 
-    def merge(self, property):
+    def merge(self, other):
         """
-        Merges the values in 'property' into self, if possible.
+        Merges the values in 'other' into self, if possible.
         """
-        self.append(list(property.value))
+        assert(isinstance(other, (BaseProperty)))
+        if self.unit is None and other.unit is not None:
+            self.unit = other.unit
+        if other.unit != self.unit:
+            raise ValueError("odml.Property.merge: src and dest units (%s, %s) do not match!"
+                             % (other.unit, self.unit))
 
-    def unmerge(self, property):
+        if self.definition is None and other.definition is not None:
+            self.definition = other.definition
+        if self.definition is not None and other.definition is not None:
+            self_def = ''.join(map(str.strip, self.definition.split())).lower()
+            other_def = ''.join(map(str.strip, other.definition.split())).lower()
+            if self_def != other_def:
+                raise ValueError("odml.Property.merge: src and dest definitions do not match!")
+
+        if self.uncertainty is not None and other.uncertainty is not None:
+            raise ValueError("odml.Property.merge: src and dest uncertainty both set and do not match!")
+        if self.uncertainty is None and other.uncertainty is not None:
+            self.uncertainty = other.uncertainty
+
+        if self.reference is not None and other.reference is not None:
+            self_ref = ''.join(map(str.strip(), self.reference.lower().split()))
+            other_ref = ''.join(map(str.strip(), other.reference.lower().split()))
+            if self_ref != other_ref:
+                raise ValueError("odml.Property.merge: src and dest references do not match!")
+        to_add = [v for v in other.value if v not in self._value]
+        self.append(to_add)
+
+    def unmerge(self, other):
         """
         Stub that doesn't do anything for this class
         """

--- a/odml/property.py
+++ b/odml/property.py
@@ -150,7 +150,7 @@ class BaseProperty(base.baseobject, Property):
 
     @property
     def value(self):
-        return tuple(self._value)
+        return self._value.copy()
 
     def value_str(self, index=0):
         """

--- a/odml/property.py
+++ b/odml/property.py
@@ -322,3 +322,14 @@ class BaseProperty(base.baseobject, Property):
 
     def __getitem__(self, key):
         return self._value[key]
+
+    def append(self, obj):
+        if self._value == []:
+            self.value = obj
+        else:
+            new_value = self._convert_value_input(obj)
+            if not self._validate_values(new_value):
+                raise ValueError("odml.Property.append: passed value(s) cannot be converted to "
+                                 "data type \'%s\'!" % self._dtype)
+            self._value.extend([dtypes.get(v, self.dtype) for v in new_value])
+

--- a/odml/property.py
+++ b/odml/property.py
@@ -190,7 +190,8 @@ class BaseProperty(base.baseobject, Property):
     @value.setter
     def value(self, new_value):
         # Make sure boolean value 'False' gets through as well...
-        if new_value is None or new_value == "":
+        if new_value is None or (isinstance(new_value, (list, tuple, str)) and len(new_value) == 0):
+            self._value = []
             return
 
         new_value = self._convert_value_input(new_value)

--- a/odml/tools/dict_parser.py
+++ b/odml/tools/dict_parser.py
@@ -80,8 +80,9 @@ class DictWriter:
 
                 if hasattr(prop, attr):
                     tag = getattr(prop, attr)
-
-                    if (tag == []) or tag:  # Even if 'value' is empty, allow '[]'
+                    if isinstance(tag, tuple):
+                        prop_dict[attr] = list(tag)
+                    elif (tag == []) or tag:  # Even if 'value' is empty, allow '[]'
                         prop_dict[attr] = tag
 
             props_seq.append(prop_dict)

--- a/odml/tools/dict_parser.py
+++ b/odml/tools/dict_parser.py
@@ -188,7 +188,7 @@ class DictReader:
                     prop_attrs[attr] = _property[attr]
 
             prop = odmlfmt.Property.create(**prop_attrs)
-            prop._value = values
+            prop.value = values
             odml_props.append(prop)
 
         return odml_props

--- a/odml/tools/dumper.py
+++ b/odml/tools/dumper.py
@@ -10,7 +10,7 @@ def get_props(obj, props):
         if hasattr(obj, p):
             x = getattr(obj, p)
             if x is not None:
-                if isinstance(x, list):
+                if isinstance(x, list) or isinstance(x, tuple):
                     out.append("%s=%s" % (p, to_csv(x)))
                 else:
                     out.append("%s=%s" % (p, repr(x)))

--- a/resources/install_osx_virtualenv.sh
+++ b/resources/install_osx_virtualenv.sh
@@ -1,19 +1,26 @@
 #!/bin/bash
-
+echo %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 echo Running install_osx_virtalenv.sh
+python --version;
+echo travis python version:  $TRAVIS_PYTHON_VERSION
+echo %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
 
     brew update;
 
     if [[ "$OSXENV" == "2.7" ]]; then
+        echo python 2.7
         brew install python;
         virtualenv venv -p python;
         source venv/bin/activate;
     else
+        echo some other version 
         brew install python3;
         virtualenv venv -p python3;
         source venv/bin/activate;
+        export PYCMD=python3;
+        export PIPCMD=pip3;
     fi
 fi
 

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -54,6 +54,16 @@ class TestProperty(unittest.TestCase):
         p.value.append(5)
         self.assertEqual(len(p.value), 0)
 
+        p5 = Property("test", value="a string")
+        p5.append("Freude")
+        self.assertEqual(len(p5), 2)
+        self.assertRaises(ValueError, p5.append, "[a, b, c]")
+        p5.extend("[a, b, c]")
+        self.assertEqual(len(p5), 5)
+
+        p6 = Property("test", {"name": "Marie", "name":"Johanna"})
+        self.assertEqual(len(p6), 1)
+
     def test_get_set_value(self):
         values = [1, 2, 3, 4, 5]
         p = Property("property", value=values)

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -53,6 +53,14 @@ class TestProperty(unittest.TestCase):
 
         p.value.append(5)
         self.assertEqual(len(p.value), 0)
+        self.assertRaises(ValueError, p.append, 5.5)
+
+        p.append(5.5, strict=False)
+        self.assertEqual(len(p), 1)
+
+        self.assertRaises(ValueError, p.extend, [3.14, 6.28])
+        p.extend([3.14, 6.28], strict=False)
+        self.assertEqual(len(p), 3)
 
         p5 = Property("test", value="a string")
         p5.append("Freude")

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -30,13 +30,13 @@ class TestProperty(unittest.TestCase):
         assert(p.dtype == 'int')
         p.dtype = DType.boolean
         assert(p.dtype == 'boolean')
-        assert(p.value == [True, False, True, False, True])
+        assert(p.value == (True, False, True, False, True))
 
         q = Property(name='sent', value=['False', True, 'TRUE', '0', 't', 'F', '1'])
         assert(q.dtype == 'string')
         q.dtype = DType.boolean
         assert(q.dtype == 'boolean')
-        assert(q.value == [False, True, True, False, True, False, True])
+        assert(q.value == (False, True, True, False, True, False, True))
 
         # Failure tests
         curr_val = [3, 0, 1, 0, 8]
@@ -46,7 +46,7 @@ class TestProperty(unittest.TestCase):
         with self.assertRaises(ValueError):
             p.dtype = DType.boolean
         assert(p.dtype == curr_type)
-        assert(p.value == curr_val)
+        assert(p.value == tuple(curr_val))
 
         curr_type = 'string'
         q = Property(name='sent', value=['False', True, 'TRUE', '0', 't', '12', 'Ft'])
@@ -62,7 +62,7 @@ class TestProperty(unittest.TestCase):
         assert(p.dtype == 'string')
         p.dtype = DType.int
         assert(p.dtype == 'int')
-        assert(p.value == [3, 0, 1, 0, 8])
+        assert(p.value == (3, 0, 1, 0, 8))
 
         # Failure Test
         p = Property(name='dogs_onboard', value=['7', '20', '1 Dog', 'Seven'])
@@ -72,7 +72,7 @@ class TestProperty(unittest.TestCase):
             p.dtype = DType.int
 
         assert(p.dtype == 'string')
-        assert(p.value == ['7', '20', '1 Dog', 'Seven'])
+        assert(p.value == ('7', '20', '1 Dog', 'Seven'))
 
     def test_name(self):
         pass

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -229,6 +229,12 @@ class TestProperty(unittest.TestCase):
         test_p.merge(p_src)
         self.assertEqual(test_p.definition, p_src.definition)
 
+        double_p = Property("adouble", value=3.14)
+        int_p = Property("aint", value=3)
+        self.assertRaises(ValueError, double_p.merge, int_p)
+
+        int_p.merge(double_p, strict=False)
+        self.assertEqual(len(int_p), 2)
 
 if __name__ == "__main__":
     print("TestProperty")

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -15,6 +15,14 @@ class TestProperty(unittest.TestCase):
         self.assertEqual(p.value[0], 100)
         self.assertEqual(type(p.value), tuple)
 
+        p.append(10)
+        self.assertEqual(len(p.value), 2)
+        p.append([20, 30, '40'])
+        self.assertEqual(len(p.value), 5)
+        with self.assertRaises(ValueError):
+            p.append('invalid')
+            p.append(('5', 6, 7))
+
     def test_bool_conversion(self):
 
         # Success tests

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -136,6 +136,8 @@ class TestProperty(unittest.TestCase):
         self.assertEqual(p.value_origin, None)
         p = Property("P", value_origin="V")
         self.assertEqual(p.value_origin, "V")
+        p.value_origin = ""
+        self.assertEqual(p.value_origin, None)
 
     def test_set_id(self):
         p = Property("P", id="79b613eb-a256-46bf-84f6-207df465b8f7")

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -16,11 +16,11 @@ class TestProperty(unittest.TestCase):
         self.assertEqual(type(p.value), list)
 
         p.append(10)
-        self.assertEqual(len(p.value), 2)
+        self.assertEqual(len(p), 2)
         self.assertRaises(ValueError, p.append, [1,2,3])
 
         p.extend([20, 30, '40'])
-        self.assertEqual(len(p.value), 5)
+        self.assertEqual(len(p), 5)
         with self.assertRaises(ValueError):
             p.append('invalid')
             p.extend(('5', 6, 7))
@@ -28,22 +28,22 @@ class TestProperty(unittest.TestCase):
         p2 = Property("property 2", 3)
         self.assertRaises(ValueError, p.append, p2)
         p.extend(p2)
-        self.assertEqual(len(p.value), 6)
+        self.assertEqual(len(p), 6)
 
         p.value = None
-        self.assertEqual(len(p.value), 0)
+        self.assertEqual(len(p), 0)
 
         p.value = [1, 2, 3]
         p.value = ""
-        self.assertEqual(len(p.value), 0)
+        self.assertEqual(len(p), 0)
 
         p.value = [1, 2, 3]
         p.value = []
-        self.assertEqual(len(p.value), 0)
+        self.assertEqual(len(p), 0)
 
         p.value = [1, 2, 3]
         p.value = ()
-        self.assertEqual(len(p.value), 0)
+        self.assertEqual(len(p), 0)
 
         p3 = Property("test", value=2, unit="Hz")
         p4 = Property("test", value=5.5, unit="s")

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -17,14 +17,17 @@ class TestProperty(unittest.TestCase):
 
         p.append(10)
         self.assertEqual(len(p.value), 2)
-        p.append([20, 30, '40'])
+        self.assertRaises(ValueError, p.append, [1,2,3])
+
+        p.extend([20, 30, '40'])
         self.assertEqual(len(p.value), 5)
         with self.assertRaises(ValueError):
             p.append('invalid')
-            p.append(('5', 6, 7))
+            p.extend(('5', 6, 7))
 
         p2 = Property("property 2", 3)
-        p.append(p2)
+        self.assertRaises(ValueError, p.append, p2)
+        p.extend(p2)
         self.assertEqual(len(p.value), 6)
 
         p.value = None

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -23,6 +23,10 @@ class TestProperty(unittest.TestCase):
             p.append('invalid')
             p.append(('5', 6, 7))
 
+        p2 = Property("property 2", 3)
+        p.append(p2)
+        self.assertEqual(len(p.value), 6)
+
     def test_bool_conversion(self):
 
         # Success tests

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -144,7 +144,52 @@ class TestProperty(unittest.TestCase):
         Property("P", id="id")
         self.assertNotEqual(p.id, "id")
 
+    def test_merge(self):
+        p_dst = Property("p1", value=[1, 2, 3], unit="Hz", definition="Freude\t schoener\nGoetterfunken\n",
+                         reference="portal.g-node.org", uncertainty=0.0)
+        p_src = Property("p2", value=[2, 4, 6], unit="Hz", definition="FREUDE schoener GOETTERfunken")
+
+        test_p = p_dst.clone()
+        test_p.merge(p_src)
+        self.assertEqual(len(test_p.value), 5)
+
+        p_inv_unit = p_src.clone()
+        p_inv_unit.unit = 's'
+
+        p_inv_def = p_src.clone()
+        p_inv_def.definition = "Freunde schoender Goetterfunken"
+
+        p_inv_uncert = p_src.clone()
+        p_inv_uncert.uncertainty = 10.0
+
+        p_inv_ref = p_src.clone()
+        p_inv_ref.reference = "test"
+
+        test_p = p_dst.clone()
+        self.assertRaises(ValueError, test_p.merge, p_inv_unit)
+        self.assertRaises(ValueError, test_p.merge, p_inv_def)
+        self.assertRaises(ValueError, test_p.merge, p_inv_uncert)
+        self.assertRaises(ValueError, test_p.merge, p_inv_ref)
+
+        test_p.reference = None
+        test_p.merge(p_src)
+        self.assertEqual(test_p.reference, p_src.reference)
+
+        test_p.unit = ""
+        test_p.merge(p_src)
+        self.assertEqual(test_p.unit, p_src.unit)
+
+        test_p.uncertainty = None
+        test_p.merge(p_src)
+        self.assertEqual(test_p.uncertainty, p_src.uncertainty)
+
+        test_p.definition = ""
+        test_p.merge(p_src)
+        self.assertEqual(test_p.definition, p_src.definition)
+
+
 if __name__ == "__main__":
     print("TestProperty")
     tp = TestProperty()
     tp.test_value()
+    tp.test_merge()

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -54,8 +54,25 @@ class TestProperty(unittest.TestCase):
         p.value.append(5)
         self.assertEqual(len(p.value), 0)
 
-    def test_bool_conversion(self):
+    def test_get_set_value(self):
+        values = [1, 2, 3, 4, 5]
+        p = Property("property", value=values)
 
+        self.assertEqual(len(p), 5)
+        for s, d in zip(values, p.value):
+            self.assertEqual(s, d)
+
+        count = 0
+        for v in p:
+            count += 1
+        self.assertEqual(count, len(values))
+
+        p[0] = 10
+        self.assertEqual(p[0], 10)
+        with self.assertRaises(ValueError):
+            p[1] = 'stringval'
+
+    def test_bool_conversion(self):
         # Success tests
         p = Property(name='received', value=[1, 0, 1, 0, 1])
         assert(p.dtype == 'int')

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -13,6 +13,7 @@ class TestProperty(unittest.TestCase):
     def test_value(self):
         p = Property("property", 100)
         self.assertEqual(p.value[0], 100)
+        self.assertEqual(type(p.value), tuple)
 
     def test_bool_conversion(self):
 

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -27,6 +27,21 @@ class TestProperty(unittest.TestCase):
         p.append(p2)
         self.assertEqual(len(p.value), 6)
 
+        p.value = None
+        self.assertEqual(len(p.value), 0)
+
+        p.value = [1, 2, 3]
+        p.value = ""
+        self.assertEqual(len(p.value), 0)
+
+        p.value = [1, 2, 3]
+        p.value = []
+        self.assertEqual(len(p.value), 0)
+
+        p.value = [1, 2, 3]
+        p.value = ()
+        self.assertEqual(len(p.value), 0)
+
     def test_bool_conversion(self):
 
         # Success tests

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -42,6 +42,12 @@ class TestProperty(unittest.TestCase):
         p.value = ()
         self.assertEqual(len(p.value), 0)
 
+        p3 = Property("test", value=2, unit="Hz")
+        p4 = Property("test", value=5.5, unit="s")
+
+        with self.assertRaises(ValueError):
+            p3.append(p4)
+
     def test_bool_conversion(self):
 
         # Success tests

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -13,7 +13,7 @@ class TestProperty(unittest.TestCase):
     def test_value(self):
         p = Property("property", 100)
         self.assertEqual(p.value[0], 100)
-        self.assertEqual(type(p.value), tuple)
+        self.assertEqual(type(p.value), list)
 
         p.append(10)
         self.assertEqual(len(p.value), 2)
@@ -48,6 +48,9 @@ class TestProperty(unittest.TestCase):
         with self.assertRaises(ValueError):
             p3.append(p4)
 
+        p.value.append(5)
+        self.assertEqual(len(p.value), 0)
+
     def test_bool_conversion(self):
 
         # Success tests
@@ -55,13 +58,13 @@ class TestProperty(unittest.TestCase):
         assert(p.dtype == 'int')
         p.dtype = DType.boolean
         assert(p.dtype == 'boolean')
-        assert(p.value == (True, False, True, False, True))
+        assert(p.value == [True, False, True, False, True])
 
         q = Property(name='sent', value=['False', True, 'TRUE', '0', 't', 'F', '1'])
         assert(q.dtype == 'string')
         q.dtype = DType.boolean
         assert(q.dtype == 'boolean')
-        assert(q.value == (False, True, True, False, True, False, True))
+        assert(q.value == [False, True, True, False, True, False, True])
 
         # Failure tests
         curr_val = [3, 0, 1, 0, 8]
@@ -71,7 +74,7 @@ class TestProperty(unittest.TestCase):
         with self.assertRaises(ValueError):
             p.dtype = DType.boolean
         assert(p.dtype == curr_type)
-        assert(p.value == tuple(curr_val))
+        assert(p.value == curr_val)
 
         curr_type = 'string'
         q = Property(name='sent', value=['False', True, 'TRUE', '0', 't', '12', 'Ft'])
@@ -81,13 +84,12 @@ class TestProperty(unittest.TestCase):
         assert(q.dtype == curr_type)
 
     def test_str_to_int_convert(self):
-
         # Success Test
         p = Property(name='cats_onboard', value=['3', '0', '1', '0', '8'])
         assert(p.dtype == 'string')
         p.dtype = DType.int
         assert(p.dtype == 'int')
-        assert(p.value == (3, 0, 1, 0, 8))
+        assert(p.value == [3, 0, 1, 0, 8])
 
         # Failure Test
         p = Property(name='dogs_onboard', value=['7', '20', '1 Dog', 'Seven'])
@@ -97,7 +99,7 @@ class TestProperty(unittest.TestCase):
             p.dtype = DType.int
 
         assert(p.dtype == 'string')
-        assert(p.value == ('7', '20', '1 Dog', 'Seven'))
+        assert(p.value == ['7', '20', '1 Dog', 'Seven'])
 
     def test_name(self):
         pass

--- a/test/test_rdf_writer.py
+++ b/test/test_rdf_writer.py
@@ -100,7 +100,7 @@ class TestRDFWriter(unittest.TestCase):
         w.convert_to_rdf()
         self.assertEqual(len(list(w.g.subjects(predicate=RDF.li, object=Literal("val")))), 1)
 
-        doc.sections[0].properties[0].value.append("val2")
+        doc.sections[0].properties[0].append("val2")
         w = RDFWriter([doc])
         w.convert_to_rdf()
         self.assertEqual(len(list(w.g.subject_objects(predicate=RDF.li))), 2)


### PR DESCRIPTION
replacement pr for #236. The following changes have been made:

1. ``prop.value`` returns a copy(!) of the value list. Manipulating this list will not affect the content of the property (fixes #227).
2. implement ``prop.append``, ``prop.extend`` methods. The first only for single convertible values, the latter for lists of such as well as other properties. (fixes #223)
3. Implement the ``__setitem__`` method for direct value manipulation. Property more or less behaves like a list. Passed values are checked for converability.
4. Implement ``prop.merge`` method. This will sync all but the dependency and dependencyValue attributes. ValueErrors are raised, if information is set in both properties but are in conflict. (fixes #221)
5. add some docstrings
6. some tests