### PR TITLE
Refactor the odML v1.0 -> 1.1 version converter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ pip-log.txt
 # Unit test / coverage reports
 .coverage
 .tox
+.cache
 
 # temp files
 *~

--- a/odml/terminology.py
+++ b/odml/terminology.py
@@ -3,20 +3,20 @@ Handles (deferred) loading of terminology data and access to it
 for odML documents
 """
 
-import os
-import tempfile
 import datetime
-import odml.tools.xmlparser
+import os
 import sys
+import tempfile
 import threading
-
-from hashlib import md5
 try:
     import urllib.request as urllib2
 except ImportError:
     import urllib2
 
+from hashlib import md5
+
 from .tools.parser_utils import ParserException
+from .tools.xmlparser import XMLReader
 
 
 REPOSITORY = 'http://portal.g-node.org/odml/terminologies/v1.1/terminologies.xml'
@@ -82,8 +82,7 @@ class Terminologies(dict):
             print("did not successfully load '%s'" % url)
             return
         try:
-            term = odml.tools.xmlparser.XMLReader(
-                filename=url, ignore_errors=True).from_file(fp)
+            term = XMLReader(filename=url, ignore_errors=True).from_file(fp)
             term.finalize()
         except ParserException as e:
             print("Failed to load %s due to parser errors" % url)

--- a/odml/terminology.py
+++ b/odml/terminology.py
@@ -19,8 +19,8 @@ from .tools.parser_utils import ParserException
 from .tools.xmlparser import XMLReader
 
 
-REPOSITORY = 'http://portal.g-node.org/odml/terminologies/v1.1/terminologies.xml'
-REPOSITORY_BASE = 'http://portal.g-node.org/odml/terminologies/'
+REPOSITORY_BASE = 'http://portal.g-node.org/odml/terminologies'
+REPOSITORY = '/'.join([REPOSITORY_BASE, 'v1.1', 'terminologies.xml'])
 
 CACHE_AGE = datetime.timedelta(days=1)
 

--- a/odml/terminology.py
+++ b/odml/terminology.py
@@ -20,6 +20,7 @@ from .tools.parser_utils import ParserException
 
 
 REPOSITORY = 'http://portal.g-node.org/odml/terminologies/v1.1/terminologies.xml'
+REPOSITORY_BASE = 'http://portal.g-node.org/odml/terminologies/'
 
 CACHE_AGE = datetime.timedelta(days=1)
 

--- a/odml/tools/__init__.py
+++ b/odml/tools/__init__.py
@@ -1,6 +1,0 @@
-from odml.tools import dumper
-from odml.tools import format_converter
-from odml.tools import odmlparser
-from odml.tools import rdf_converter
-from odml.tools import version_converter
-from odml.tools import xmlparser

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -28,6 +28,15 @@ class VersionConverter(object):
         self.filename = filename
         self.conversion_log = []
 
+    def convert(self):
+        """
+        This method returns the content of the provided file object converted
+        to odML version 1.1 as a string object which is directly consumable
+        by the odml.tools.ODMLReader.
+        """
+        tree = self.convert_odml_file()
+        return ET.tounicode(tree, pretty_print=True) if tree else ""
+
     def convert_odml_file(self):
         """
         Converts a given file to the odml version 1.1.

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -30,8 +30,7 @@ class VersionConverter(object):
     def __init__(self, filename):
         self.filename = filename
 
-    @classmethod
-    def convert_odml_file(cls, filename):
+    def convert_odml_file(self, filename):
         """
         Converts a given file to the odml version 1.1.
         Unites multiple value objects and brings value attributes out of the <value> tag.
@@ -39,10 +38,10 @@ class VersionConverter(object):
         """
         tree = None
         if isinstance(filename, io.StringIO):
-            cls._fix_unmatching_tags(filename)
+            self._fix_unmatching_tags(filename)
             tree = ET.ElementTree(ET.fromstring(filename.getvalue()))
         elif os.path.exists(filename) and os.path.getsize(filename) > 0:
-            cls._fix_unmatching_tags(filename)
+            self._fix_unmatching_tags(filename)
             # Make pretty print available by resetting format
             parser = ET.XMLParser(remove_blank_text=True)
             tree = ET.parse(filename, parser)
@@ -51,7 +50,7 @@ class VersionConverter(object):
                   "nor io.StringIO object".format(filename))
             return
 
-        tree = cls._replace_same_name_entities(tree)
+        tree = self._replace_same_name_entities(tree)
         root = tree.getroot()
         root.set("version", FORMAT_VERSION)
 
@@ -72,8 +71,8 @@ class VersionConverter(object):
                     if val_elem.tag != "value":
                         # Check whether current Value attribute has already been exported
                         # under its own or a different name. Give a warning, if the values differ.
-                        check_export = value.getparent().find(cls._version_map[val_elem.tag]) \
-                            if val_elem.tag in cls._version_map else value.getparent().find(val_elem.tag)
+                        check_export = value.getparent().find(self._version_map[val_elem.tag]) \
+                            if val_elem.tag in self._version_map else value.getparent().find(val_elem.tag)
 
                         if check_export is not None:
                             if check_export.text != val_elem.text:
@@ -85,8 +84,8 @@ class VersionConverter(object):
                             new_elem = ET.Element(val_elem.tag)
                             new_elem.text = val_elem.text
                             value.getparent().append(new_elem)
-                        elif val_elem.tag in cls._version_map:
-                            new_elem = ET.Element(cls._version_map[val_elem.tag])
+                        elif val_elem.tag in self._version_map:
+                            new_elem = ET.Element(self._version_map[val_elem.tag])
                             new_elem.text = val_elem.text
                             value.getparent().append(new_elem)
                         else:
@@ -138,8 +137,7 @@ class VersionConverter(object):
 
         return tree
 
-    @classmethod
-    def _fix_unmatching_tags(cls, filename):
+    def _fix_unmatching_tags(self, filename):
         """
         Fix an xml file by deleting known mismatching tags.
         :param filename: The path to the file or io.StringIO object
@@ -150,9 +148,9 @@ class VersionConverter(object):
         elif os.path.exists(filename) and os.path.getsize(filename) > 0:
             f = open(filename, 'r+')
             doc = f.read()
-        for k, v in cls._error_strings.items():
+        for k, v in self._error_strings.items():
             if k in doc:
-                doc = doc.replace(k, cls._error_strings[k])
+                doc = doc.replace(k, self._error_strings[k])
                 changes = True
 
         if changes:
@@ -163,8 +161,7 @@ class VersionConverter(object):
                 f.write(doc)
                 f.close()
 
-    @classmethod
-    def _replace_same_name_entities(cls, tree):
+    def _replace_same_name_entities(self, tree):
         """
         Changes same section names in the doc by adding <-{index}> to the next section occurrences.
         :param tree: ElementTree of the doc
@@ -176,14 +173,14 @@ class VersionConverter(object):
         for sec in root.iter("section"):
             n = sec.find("name")
             if n is not None:
-                cls._change_entity_name(sec_map, n)
+                self._change_entity_name(sec_map, n)
             else:
                 raise Exception("Section attribute name is not specified")
             for prop in sec.iter("property"):
                 if prop.getparent() == sec:
                     n = prop.find("name")
                     if n is not None:
-                        cls._change_entity_name(prop_map, n)
+                        self._change_entity_name(prop_map, n)
             prop_map.clear()
         return tree
 

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -190,6 +190,32 @@ class VersionConverter(object):
                 f.write(doc)
                 f.close()
 
+    def _parse_document(self):
+        """
+        _parse_document checks whether the provided file object can be parsed,
+        fixes known mismatching elements and returns the parsed lxml tree.
+        :return: ElementTree
+        """
+        if isinstance(self.filename, io.StringIO):
+            doc = self.filename.getvalue()
+        elif os.path.exists(self.filename) and os.path.getsize(self.filename) > 0:
+            with open(self.filename, 'r+') as file:
+                doc = file.read()
+        else:
+            msg = "Cannot parse provided file object '%s'." % self.filename
+            raise Exception(msg)
+
+        # Fix known mismatching elements
+        for elem, val in self._error_strings.items():
+            if elem in doc:
+                doc = doc.replace(elem, val)
+
+        # Make pretty print available by resetting format
+        parser = ET.XMLParser(remove_blank_text=True)
+        tree = ET.ElementTree(ET.fromstring(doc, parser))
+
+        return tree
+
     @classmethod
     def _replace_same_name_entities(cls, tree):
         """

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -32,25 +32,11 @@ class VersionConverter(object):
         """
         Converts a given file to the odml version 1.1.
         Unites multiple value objects and brings value attributes out of the <value> tag.
-        :param filename: The path to the file or io.StringIO object
         """
         # Reset status messages
         self.conversion_log = []
 
-        tree = None
-        if isinstance(self.filename, io.StringIO):
-            self._fix_unmatching_tags()
-            tree = ET.ElementTree(ET.fromstring(self.filename.getvalue()))
-        elif os.path.exists(self.filename) and os.path.getsize(self.filename) > 0:
-            self._fix_unmatching_tags()
-            # Make pretty print available by resetting format
-            parser = ET.XMLParser(remove_blank_text=True)
-            tree = ET.parse(self.filename, parser)
-        else:
-            self._log("File '%s' is not an .xml file nor "
-                      "an io.StringIO object" % self.filename)
-            return
-
+        tree = self._parse_document()
         tree = self._replace_same_name_entities(tree)
         root = tree.getroot()
         root.set("version", FORMAT_VERSION)

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -1,6 +1,8 @@
 import io
+import json
 import os
 import sys
+import yaml
 
 from lxml import etree as ET
 from .. import format
@@ -55,6 +57,18 @@ class VersionConverter(object):
         tree = ET.ElementTree(ET.fromstring(doc, parser))
 
         return tree
+
+    def _parse_json(self):
+        with open(self.filename) as file:
+            parsed_doc = json.load(file)
+
+        return self._parse_dict_document(parsed_doc)
+
+    def _parse_yaml(self):
+        with open(self.filename) as file:
+            parsed_doc = yaml.load(file)
+
+        return self._parse_dict_document(parsed_doc)
 
     @classmethod
     def _parse_dict_document(cls, parsed_doc):

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -30,24 +30,24 @@ class VersionConverter(object):
     def __init__(self, filename):
         self.filename = filename
 
-    def convert_odml_file(self, filename):
+    def convert_odml_file(self):
         """
         Converts a given file to the odml version 1.1.
         Unites multiple value objects and brings value attributes out of the <value> tag.
         :param filename: The path to the file or io.StringIO object
         """
         tree = None
-        if isinstance(filename, io.StringIO):
-            self._fix_unmatching_tags(filename)
-            tree = ET.ElementTree(ET.fromstring(filename.getvalue()))
-        elif os.path.exists(filename) and os.path.getsize(filename) > 0:
-            self._fix_unmatching_tags(filename)
+        if isinstance(self.filename, io.StringIO):
+            self._fix_unmatching_tags()
+            tree = ET.ElementTree(ET.fromstring(self.filename.getvalue()))
+        elif os.path.exists(self.filename) and os.path.getsize(self.filename) > 0:
+            self._fix_unmatching_tags()
             # Make pretty print available by resetting format
             parser = ET.XMLParser(remove_blank_text=True)
-            tree = ET.parse(filename, parser)
+            tree = ET.parse(self.filename, parser)
         else:
             print("File \"{}\" has not been converted because it is not a valid path to odml .xml file "
-                  "nor io.StringIO object".format(filename))
+                  "nor io.StringIO object".format(self.filename))
             return
 
         tree = self._replace_same_name_entities(tree)
@@ -137,16 +137,16 @@ class VersionConverter(object):
 
         return tree
 
-    def _fix_unmatching_tags(self, filename):
+    def _fix_unmatching_tags(self):
         """
         Fix an xml file by deleting known mismatching tags.
         :param filename: The path to the file or io.StringIO object
         """
         changes = False
-        if isinstance(filename, io.StringIO):
-            doc = filename.getvalue()
-        elif os.path.exists(filename) and os.path.getsize(filename) > 0:
-            f = open(filename, 'r+')
+        if isinstance(self.filename, io.StringIO):
+            doc = self.filename.getvalue()
+        elif os.path.exists(self.filename) and os.path.getsize(self.filename) > 0:
+            f = open(self.filename, 'r+')
             doc = f.read()
         for k, v in self._error_strings.items():
             if k in doc:
@@ -154,7 +154,7 @@ class VersionConverter(object):
                 changes = True
 
         if changes:
-            if isinstance(filename, io.StringIO):
+            if isinstance(self.filename, io.StringIO):
                 return io.StringIO(doc)
             else:
                 f.truncate(0)
@@ -193,11 +193,11 @@ class VersionConverter(object):
             name.text += "-" + str(elem_map[name.text])
 
     def __str__(self):
-        tree = self.convert_odml_file(self.filename)
+        tree = self.convert_odml_file()
         return ET.tounicode(tree, pretty_print=True) if tree else ""
 
     def __unicode__(self):
-        tree = self.convert_odml_file(self.filename)
+        tree = self.convert_odml_file()
         return ET.tounicode(tree, pretty_print=True) if tree else ""
 
     def write_to_file(self, filename):

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -56,6 +56,28 @@ class VersionConverter(object):
 
         return tree
 
+    @classmethod
+    def _parse_dict_properties(cls, parent_element, props_list):
+        """
+        _parse_dict_properties parses a list containing python dictionaries of v1.0 odML
+        style properties into lxml.Element XML equivalents and appends the parsed
+        Properties to the provided lxml.Element parent.
+        :param parent_element: lxml.Element to which parsed properties will be appended.
+        :param props_list: list of python dictionaries containing valid v1.0 odML
+                           Properties.
+        """
+        for curr_prop in props_list:
+            prop = ET.Element("property")
+            for element in curr_prop:
+                if element == 'values':
+                    cls._parse_dict_values(prop, curr_prop['values'])
+                elif element:
+                    elem = ET.Element(element)
+                    elem.text = curr_prop[element]
+                    prop.append(elem)
+
+            parent_element.append(prop)
+
     @staticmethod
     def _parse_dict_values(parent_element, value_list):
         """

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -56,6 +56,28 @@ class VersionConverter(object):
 
         return tree
 
+    @staticmethod
+    def _parse_dict_values(parent_element, value_list):
+        """
+        _parse_dict_values parses a list containing python dictionaries of v1.0 odML
+        style values into lxml.Element XML equivalents and appends the parsed
+        Values to the provided lxml.Element parent.
+        :param parent_element: lxml.Element to which parsed values will be appended.
+        :param value_list: list of python dictionaries containing valid v1.0 odML Values.
+        """
+        for value in value_list:
+            val = ET.Element("value")
+            for element in value:
+                if element:
+                    if element == 'value':
+                        val.text = str(value[element])
+                    else:
+                        elem = ET.Element(element)
+                        elem.text = str(value[element])
+                        val.append(elem)
+
+            parent_element.append(val)
+
     def _convert(self, tree):
         """
         Converts an lxml.ElementTree containing a v1.0 odML document to odML v1.1.

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -231,7 +231,6 @@ class VersionConverter(object):
         else:
             data = str(self)
         if data and "<odML " in data:
-            f = open(filename, "w")
-            f.write('<?xml version="1.0" encoding="UTF-8"?>\n')
-            f.write(data)
-            f.close()
+            with open(filename, "w") as file:
+                file.write('<?xml version="1.0" encoding="UTF-8"?>\n')
+                file.write(data)

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -36,10 +36,10 @@ class VersionConverter(object):
         to odML version 1.1 as a string object which is directly consumable
         by the odml.tools.ODMLReader.
         """
-        tree = self.convert_odml_file()
+        tree = self._convert()
         return ET.tounicode(tree, pretty_print=True) if tree else ""
 
-    def convert_odml_file(self):
+    def _convert(self):
         """
         Converts a given file to the odml version 1.1.
         Unites multiple value objects and brings value attributes out of the <value> tag.
@@ -47,7 +47,7 @@ class VersionConverter(object):
         # Reset status messages
         self.conversion_log = []
 
-        tree = self._parse_document()
+        tree = self._parse_xml()
         tree = self._replace_same_name_entities(tree)
         root = tree.getroot()
         root.set("version", FORMAT_VERSION)
@@ -211,9 +211,9 @@ class VersionConverter(object):
                     self._log("[Info] Omitted non-Value attribute '%s: %s/%s'"
                               % (log_id, val_elem.tag, val_elem.text))
 
-    def _parse_document(self):
+    def _parse_xml(self):
         """
-        _parse_document checks whether the provided file object can be parsed,
+        _parse_xml checks whether the provided file object can be parsed,
         fixes known mismatching elements and returns the parsed lxml tree.
         :return: ElementTree
         """
@@ -278,11 +278,11 @@ class VersionConverter(object):
         print(msg)
 
     def __str__(self):
-        tree = self.convert_odml_file()
+        tree = self._convert()
         return ET.tounicode(tree, pretty_print=True) if tree else ""
 
     def __unicode__(self):
-        tree = self.convert_odml_file()
+        tree = self._convert()
         return ET.tounicode(tree, pretty_print=True) if tree else ""
 
     def write_to_file(self, filename):

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -106,7 +106,7 @@ class VersionConverter(object):
             parent = p.getparent()
             parent.remove(p)
 
-        # Exclude unsupported Section attributes, ignore comments
+        # Exclude unsupported Section attributes, ignore comments, handle repositories
         for sec in root.iter("section"):
             sec_name = sec.find("name").text
             for e in sec:
@@ -114,13 +114,21 @@ class VersionConverter(object):
                     self._log("[Info] Omitted non-Section attribute "
                               "'%s: %s/%s'" % (sec_name, e.tag, e.text))
                     sec.remove(e)
+                    continue
 
-        # Exclude unsupported Document attributes, ignore comments
+                if e.tag == "repository":
+                    self._handle_repository(e)
+
+        # Exclude unsupported Document attributes, ignore comments, handle repositories
         for e in root:
             if e.tag not in format.Document.arguments_keys and isinstance(e.tag, str):
                 self._log("[Info] Omitted non-Document "
                           "attribute '%s/%s'" % (e.tag, e.text))
                 root.remove(e)
+                continue
+
+            if e.tag == "repository":
+                self._handle_repository(e)
 
         return tree
 

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -18,7 +18,8 @@ class VersionConverter(object):
     Class for converting odml xml files from version 1.0 to 1.1
     """
     _version_map = {
-        'filename': 'value_origin'
+        'filename': 'value_origin',
+        'dtype': 'type'
     }
 
     _error_strings = {
@@ -160,12 +161,16 @@ class VersionConverter(object):
 
                 prop.append(main_val)
 
-            # Exclude unsupported Property attributes, ignore comments
-            for e in prop:
-                if e.tag not in format.Property.arguments_keys and isinstance(e.tag, str):
+            # Reverse map "dependency_value", exclude unsupported Property attributes.
+            for elem in prop:
+                if elem.tag == "dependency_value":
+                    elem.tag = "dependencyvalue"
+
+                if (elem.tag not in format.Property.arguments_keys and
+                        isinstance(elem.tag, str)):
                     self._log("[Info] Omitted non-Property attribute "
-                              "'%s: %s/%s'" % (prop_id, e.tag, e.text))
-                    prop.remove(e)
+                              "'%s: %s/%s'" % (prop_id, elem.tag, elem.text))
+                    prop.remove(elem)
 
     def _handle_value(self, value, log_id):
         """

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -132,22 +132,25 @@ class VersionConverter(object):
         """
         Values changed from odML v1.0 to v1.1. This function moves all supported
         odML Property elements from a v1.0 Value element to the parent Property element.
-        :param value: etree element containing the v1.0 Value
+        Adds a log entry for every non-exported element.
+        :param value: etree element containing the v1.0 Value.
         :param log_id: String containing Section and Property name and type to log
-                       omitted tags and value contents.
+                       omitted elements and value contents.
         """
         for val_elem in value.iter():
             if val_elem.tag != "value":
                 # Check whether current Value attribute has already been exported
                 # under its own or a different name. Give a warning, if the values differ.
-                check_export = value.getparent().find(self._version_map[val_elem.tag]) \
-                    if val_elem.tag in self._version_map else value.getparent().find(
-                    val_elem.tag)
+                parent = value.getparent()
+                if val_elem.tag in self._version_map:
+                    check_export = parent.find(self._version_map[val_elem.tag])
+                else:
+                    check_export = parent.find(val_elem.tag)
 
                 if check_export is not None:
                     if check_export.text != val_elem.text:
-                        self._log("[Warning] Property '%s' Value  attribute '%s/%s' "
-                                  "already  exported, omitting '%s'"
+                        self._log("[Warning] Value element '%s: %s/%s' already exported, "
+                                  "omitting further element value '%s'"
                                   % (log_id, val_elem.tag,
                                      check_export.text, val_elem.text))
 
@@ -155,11 +158,11 @@ class VersionConverter(object):
                 elif val_elem.tag in format.Property.arguments_keys:
                     new_elem = ET.Element(val_elem.tag)
                     new_elem.text = val_elem.text
-                    value.getparent().append(new_elem)
+                    parent.append(new_elem)
                 elif val_elem.tag in self._version_map:
                     new_elem = ET.Element(self._version_map[val_elem.tag])
                     new_elem.text = val_elem.text
-                    value.getparent().append(new_elem)
+                    parent.append(new_elem)
                 else:
                     self._log("[Info] Omitted non-Value attribute '%s: %s/%s'"
                               % (log_id, val_elem.tag, val_elem.text))

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -57,6 +57,30 @@ class VersionConverter(object):
         return tree
 
     @classmethod
+    def _parse_dict_sections(cls, parent_element, section_list):
+        """
+        _parse_dict_sections parses a list containing python dictionaries of v1.0 odML
+        style sections into lxml.Element XML equivalents and appends the parsed Sections
+        to the provided lxml.Element parent.
+        :param parent_element: lxml.Element to which parsed sections will be appended.
+        :param section_list: list of python dictionaries containing valid v1.0 odML
+                             Sections.
+        """
+        for section in section_list:
+            sec = ET.Element("section")
+            for element in section:
+                if element == 'properties':
+                    cls._parse_dict_properties(sec, section['properties'])
+                elif element == 'sections':
+                    cls._parse_dict_sections(sec, section['sections'])
+                elif element:
+                    elem = ET.Element(element)
+                    elem.text = section[element]
+                    sec.append(elem)
+
+            parent_element.append(sec)
+
+    @classmethod
     def _parse_dict_properties(cls, parent_element, props_list):
         """
         _parse_dict_properties parses a list containing python dictionaries of v1.0 odML

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -5,6 +5,7 @@ import sys
 from lxml import etree as ET
 from .. import format
 from ..info import FORMAT_VERSION
+from ..terminology import Terminologies, REPOSITORY_BASE
 
 try:
     unicode = unicode
@@ -122,6 +123,37 @@ class VersionConverter(object):
                 root.remove(e)
 
         return tree
+
+    def _handle_repository(self, element):
+        """
+        The method handles provided odML repositories.
+        :param element: lxml element containing the provided odML repository link.
+        """
+        content = element.text
+        cache = {}
+        term_handler = Terminologies(cache)
+        term = term_handler.load(element.text)
+
+        # If the repository url can be loaded and parsed, everything is fine.
+        if term is not None:
+            return
+
+        # If the repository url is a v1.0 odml-terminology one,
+        # check whether a v1.1 is available and use it instead.
+        if os.path.join(REPOSITORY_BASE, "v1.0") in element.text:
+            element.text = element.text.replace('v1.0', 'v1.1')
+            term = term_handler.load(element.text)
+
+            if term is not None:
+                msg = "[Info] Replaced repository url '%s' with '%s'." \
+                      % (content, element.text)
+                self._log(msg)
+                return
+
+        # Remove a repo element if no v1.1 compatible repository url can be provided.
+        parent = element.getparent()
+        parent.remove(element)
+        self._log("[Warning] Excluded v1.0 repository '%s'." % content)
 
     def _handle_value(self, value, log_id):
         """

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -277,10 +277,20 @@ class VersionConverter(object):
         return ET.tounicode(tree, pretty_print=True) if tree else ""
 
     def write_to_file(self, filename):
+        """
+        This method converts the content of the provided converter file object
+        to odML version 1.1 and writes the results to `filename`.
+        :param filename: Output file.
+        """
         if sys.version_info < (3,):
             data = unicode(self).encode('utf-8')
         else:
             data = str(self)
+
+        ext = [".xml", ".odml"]
+        if not filename.endswith(tuple(ext)):
+            filename = "%s.xml" % filename
+
         if data and "<odML " in data:
             with open(filename, "w") as file:
                 file.write('<?xml version="1.0" encoding="UTF-8"?>\n')

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -140,7 +140,6 @@ class VersionConverter(object):
     def _fix_unmatching_tags(self):
         """
         Fix an xml file by deleting known mismatching tags.
-        :param filename: The path to the file or io.StringIO object
         """
         changes = False
         if isinstance(self.filename, io.StringIO):
@@ -161,7 +160,8 @@ class VersionConverter(object):
                 f.write(doc)
                 f.close()
 
-    def _replace_same_name_entities(self, tree):
+    @classmethod
+    def _replace_same_name_entities(cls, tree):
         """
         Changes same section names in the doc by adding <-{index}> to the next section occurrences.
         :param tree: ElementTree of the doc
@@ -173,14 +173,14 @@ class VersionConverter(object):
         for sec in root.iter("section"):
             n = sec.find("name")
             if n is not None:
-                self._change_entity_name(sec_map, n)
+                cls._change_entity_name(sec_map, n)
             else:
                 raise Exception("Section attribute name is not specified")
             for prop in sec.iter("property"):
                 if prop.getparent() == sec:
                     n = prop.find("name")
                     if n is not None:
-                        self._change_entity_name(prop_map, n)
+                        cls._change_entity_name(prop_map, n)
             prop_map.clear()
         return tree
 

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -57,6 +57,30 @@ class VersionConverter(object):
         return tree
 
     @classmethod
+    def _parse_dict_document(cls, parsed_doc):
+        """
+        _parse_dict_document parses a python dictionary containing a valid
+        v1.0 odML document into an lxml.ElementTree XML equivalent and returns
+        the resulting lxml ElementTree.
+        :param parsed_doc: python dictionary containing a valid v1.0 odML document.
+        :return: lxml ElementTree
+        """
+        root = ET.Element("odML")
+
+        parsed_doc = parsed_doc['Document']
+
+        for elem in parsed_doc:
+            if elem == 'sections':
+                cls._parse_dict_sections(root, parsed_doc['sections'])
+            elif elem:
+                curr_element = ET.Element(elem)
+                curr_element.text = parsed_doc[elem]
+                root.append(curr_element)
+
+        print(ET.tounicode(root, pretty_print=True))
+        return ET.ElementTree(root)
+
+    @classmethod
     def _parse_dict_sections(cls, parent_element, section_list):
         """
         _parse_dict_sections parses a list containing python dictionaries of v1.0 odML

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -407,11 +407,11 @@ class VersionConverter(object):
         print(msg)
 
     def __str__(self):
-        tree = self._convert()
+        tree = self.convert()
         return ET.tounicode(tree, pretty_print=True) if tree else ""
 
     def __unicode__(self):
-        tree = self._convert()
+        tree = self.convert()
         return ET.tounicode(tree, pretty_print=True) if tree else ""
 
     def convert(self, backend="XML"):
@@ -432,16 +432,16 @@ class VersionConverter(object):
         tree = self._convert(old_tree)
         return ET.tounicode(tree, pretty_print=True) if tree else ""
 
-    def write_to_file(self, filename):
+    def write_to_file(self, filename, backend="XML"):
         """
         This method converts the content of the provided converter file object
         to odML version 1.1 and writes the results to `filename`.
         :param filename: Output file.
+        :param backend: Format of the source file, default is XML.
         """
+        data = self.convert(backend)
         if sys.version_info < (3,):
-            data = unicode(self).encode('utf-8')
-        else:
-            data = str(self)
+            data = data.encode('utf-8')
 
         ext = [".xml", ".odml"]
         if not filename.endswith(tuple(ext)):

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -231,10 +231,8 @@ class VersionConverter(object):
                 self._log(msg)
                 return
 
-        # Remove a repo element if no v1.1 compatible repository url can be provided.
-        parent = element.getparent()
-        parent.remove(element)
-        self._log("[Warning] Excluded v1.0 repository '%s'." % content)
+        # Print a warning, if no v1.1 compatible repository url can be provided.
+        self._log("[Warning] Repository file '%s' is not odML v1.1 compatible." % content)
 
     def _handle_properties(self, root):
         """

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -383,13 +383,20 @@ class VersionConverter(object):
         tree = self._convert()
         return ET.tounicode(tree, pretty_print=True) if tree else ""
 
-    def convert(self):
+    def convert(self, backend="XML"):
         """
         This method returns the content of the provided file object converted
         to odML version 1.1 as a string object which is directly consumable
         by the odml.tools.ODMLReader.
         """
-        old_tree = self._parse_xml()
+        if backend.upper() == "JSON":
+            old_tree = self._parse_json()
+        elif backend.upper() == "YAML":
+            old_tree = self._parse_yaml()
+        elif backend.upper() == "XML":
+            old_tree = self._parse_xml()
+        else:
+            raise Exception("Unknown backend, only XML, JSON and YAML are supported.")
 
         tree = self._convert(old_tree)
         return ET.tounicode(tree, pretty_print=True) if tree else ""

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -224,7 +224,7 @@ class VersionConverter(object):
 
         # If the include url is a v1.0 odml-terminology one,
         # check whether a v1.1 is available and use it instead.
-        if os.path.join(REPOSITORY_BASE, "v1.0") in element.text:
+        if '/'.join([REPOSITORY_BASE, "v1.0"]) in element.text:
             element.text = element.text.replace('v1.0', 'v1.1')
             term = term_handler.load(element.text)
 
@@ -254,7 +254,7 @@ class VersionConverter(object):
 
         # If the repository url is a v1.0 odml-terminology one,
         # check whether a v1.1 is available and use it instead.
-        if os.path.join(REPOSITORY_BASE, "v1.0") in element.text:
+        if '/'.join([REPOSITORY_BASE, "v1.0"]) in element.text:
             element.text = element.text.replace('v1.0', 'v1.1')
             term = term_handler.load(element.text)
 

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -16,8 +16,6 @@ class VersionConverter(object):
     """
     Class for converting odml xml files from version 1.0 to 1.1
     """
-    header = """<?xml version="1.0" encoding="UTF-8"?>\n"""
-
     _version_map = {
         'type': 'type',
         'filename': 'value_origin'
@@ -207,6 +205,6 @@ class VersionConverter(object):
             data = str(self)
         if data and "<odML " in data:
             f = open(filename, "w")
-            f.write(self.header)
+            f.write('<?xml version="1.0" encoding="UTF-8"?>\n')
             f.write(data)
             f.close()

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -153,29 +153,6 @@ class VersionConverter(object):
                     self._log("[Info] Omitted non-Value attribute '%s: %s/%s'"
                               % (log_id, val_elem.tag, val_elem.text))
 
-    def _fix_unmatching_tags(self):
-        """
-        Fix an xml file by deleting known mismatching tags.
-        """
-        changes = False
-        if isinstance(self.filename, io.StringIO):
-            doc = self.filename.getvalue()
-        elif os.path.exists(self.filename) and os.path.getsize(self.filename) > 0:
-            f = open(self.filename, 'r+')
-            doc = f.read()
-        for k, v in self._error_strings.items():
-            if k in doc:
-                doc = doc.replace(k, self._error_strings[k])
-                changes = True
-
-        if changes:
-            if isinstance(self.filename, io.StringIO):
-                return io.StringIO(doc)
-            else:
-                f.truncate(0)
-                f.write(doc)
-                f.close()
-
     def _parse_document(self):
         """
         _parse_document checks whether the provided file object can be parsed,

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -17,7 +17,6 @@ class VersionConverter(object):
     Class for converting odml xml files from version 1.0 to 1.1
     """
     _version_map = {
-        'type': 'type',
         'filename': 'value_origin'
     }
 

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -36,18 +36,21 @@ class VersionConverter(object):
         to odML version 1.1 as a string object which is directly consumable
         by the odml.tools.ODMLReader.
         """
-        tree = self._convert()
+        old_tree = self._parse_xml()
+
+        tree = self._convert(old_tree)
         return ET.tounicode(tree, pretty_print=True) if tree else ""
 
-    def _convert(self):
+    def _convert(self, tree):
         """
-        Converts a given file to the odml version 1.1.
-        Unites multiple value objects and brings value attributes out of the <value> tag.
+        Converts an lxml.ElementTree containing a v1.0 odML document to odML v1.1.
+        Unites multiple value objects and moves all supported Value elements to
+        its parent Property. Exports only Document, Section and Property elements,
+        that are supported by odML v1.1.
         """
         # Reset status messages
         self.conversion_log = []
 
-        tree = self._parse_xml()
         tree = self._replace_same_name_entities(tree)
         root = tree.getroot()
         root.set("version", FORMAT_VERSION)

--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -48,7 +48,7 @@ class VersionConverter(object):
             tree = ET.parse(self.filename, parser)
         else:
             self._update_messages("File '%s' is not an .xml file "
-                                         "nor an io.StringIO object" % self.filename)
+                                  "nor an io.StringIO object" % self.filename)
             return
 
         tree = self._replace_same_name_entities(tree)
@@ -65,7 +65,14 @@ class VersionConverter(object):
                 rem_property.append(prop)
                 continue
 
-            prop_name = prop.find("name").text
+            curr_sec = prop.getparent()
+            sname = "unnamed"
+            if curr_sec.find("name") is not None:
+                sname = curr_sec.find("name").text
+            stype = "untyped"
+            if curr_sec.find("type") is not None:
+                stype = curr_sec.find("type").text
+            prop_id = "%s|%s:%s" % (sname, stype, prop.find("name").text)
             # Special handling of Values
             for value in prop.iter("value"):
                 for val_elem in value.iter():
@@ -80,7 +87,7 @@ class VersionConverter(object):
                                 self._update_messages("[Warning] Property '%s' Value "
                                                       "attribute '%s/%s' already "
                                                       "exported, omitting '%s'" %
-                                                      (prop_name, val_elem.tag,
+                                                      (prop_id, val_elem.tag,
                                                        check_export.text, val_elem.text))
 
                         # Include only supported Property attributes
@@ -94,7 +101,7 @@ class VersionConverter(object):
                             value.getparent().append(new_elem)
                         else:
                             self._update_messages("[Info] Omitted non-Value attribute "
-                                                  "'%s: %s/%s'" % (prop_name,
+                                                  "'%s: %s/%s'" % (prop_id,
                                                                    val_elem.tag,
                                                                    val_elem.text))
 
@@ -119,7 +126,7 @@ class VersionConverter(object):
             for e in prop:
                 if e.tag not in format.Property.arguments_keys and isinstance(e.tag, str):
                     self._update_messages("[Info] Omitted non-Property attribute "
-                                          "'%s: %s/%s'" % (prop_name, e.tag, e.text))
+                                          "'%s: %s/%s'" % (prop_id, e.tag, e.text))
                     prop.remove(e)
 
         # Exclude Properties without name tags

--- a/test/resources/local_repository_file_v1.0.xml
+++ b/test/resources/local_repository_file_v1.0.xml
@@ -1,0 +1,6 @@
+<odML version="1.0">
+    <section>
+        <name>Repository test</name>
+        <type>odML 1.0 document</type>
+    </section>
+</odML>

--- a/test/resources/local_repository_file_v1.1.xml
+++ b/test/resources/local_repository_file_v1.1.xml
@@ -1,0 +1,6 @@
+<odML version="1.1">
+    <section>
+        <name>Repository test</name>
+        <type>odML 1.1 document</type>
+    </section>
+</odML>

--- a/test/test_version_converter.py
+++ b/test/test_version_converter.py
@@ -66,7 +66,7 @@ class TestVersionConverter(unittest.TestCase):
         self.assertEqual(props_names[0], props_names[1])
 
         tree = ET.ElementTree(root)
-        tree = VC._replace_same_name_entities(tree)
+        tree = VC('')._replace_same_name_entities(tree)
         root = tree.getroot()
         sec_names = []
         sec_elems = []
@@ -83,17 +83,17 @@ class TestVersionConverter(unittest.TestCase):
         self.assertEqual(props_names[1], "prop_name-2")
 
     def test_fix_unmatching_tags(self):
-        first_elem = list(VC._error_strings.keys())[0]
+        first_elem = list(VC('')._error_strings.keys())[0]
         self.doc = re.sub("<value>", "<value>" + first_elem, self.doc, count=1)
         file = io.StringIO(unicode(self.doc))
         with self.assertRaises(Exception):
             ET.fromstring(file.getvalue())
-        file = VC._fix_unmatching_tags(file)
+        file = VC('')._fix_unmatching_tags(file)
         with self.assertNotRaises(Exception):
             ET.fromstring(file.getvalue())
 
     def test_convert_odml_file(self):
-        self.assertEqual(VC.convert_odml_file("/not_valid_path"), None)
+        self.assertEqual(VC('').convert_odml_file("/not_valid_path"), None)
         root = ET.fromstring(self.doc)
         prop = root.find("section").find("property")
         val_elems = []
@@ -107,7 +107,7 @@ class TestVersionConverter(unittest.TestCase):
         self.assertEqual(prop.find("type"), None)
 
         file = io.StringIO(unicode(self.doc))
-        tree = VC.convert_odml_file(file)
+        tree = VC('').convert_odml_file(file)
         root = tree.getroot()
         prop = root.find("section").find("property")
         val_elems = []
@@ -150,7 +150,7 @@ class TestVersionConverter(unittest.TestCase):
         """
 
         file = io.StringIO(unicode(doc))
-        conv_doc = VC.convert_odml_file(file)
+        conv_doc = VC('').convert_odml_file(file)
         root = conv_doc.getroot()
         # Test export of Document tags
         self.assertEqual(len(root.findall("author")), 1)
@@ -207,7 +207,7 @@ class TestVersionConverter(unittest.TestCase):
         """
 
         file = io.StringIO(unicode(doc))
-        conv_doc = VC.convert_odml_file(file)
+        conv_doc = VC('').convert_odml_file(file)
         root = conv_doc.getroot()
 
         sec = root.findall("section")
@@ -275,7 +275,7 @@ class TestVersionConverter(unittest.TestCase):
         """
 
         file = io.StringIO(unicode(doc))
-        conv_doc = VC.convert_odml_file(file)
+        conv_doc = VC('').convert_odml_file(file)
         root = conv_doc.getroot()
         sec = root.findall("section")
 
@@ -377,7 +377,7 @@ class TestVersionConverter(unittest.TestCase):
         """
 
         file = io.StringIO(unicode(doc))
-        conv_doc = VC.convert_odml_file(file)
+        conv_doc = VC('').convert_odml_file(file)
         root = conv_doc.getroot()
         sec = root.find("section")
         self.assertEqual(len(sec), 7)

--- a/test/test_version_converter.py
+++ b/test/test_version_converter.py
@@ -66,7 +66,7 @@ class TestVersionConverter(unittest.TestCase):
         self.assertEqual(props_names[0], props_names[1])
 
         tree = ET.ElementTree(root)
-        tree = VC('')._replace_same_name_entities(tree)
+        tree = VC._replace_same_name_entities(tree)
         root = tree.getroot()
         sec_names = []
         sec_elems = []
@@ -83,17 +83,17 @@ class TestVersionConverter(unittest.TestCase):
         self.assertEqual(props_names[1], "prop_name-2")
 
     def test_fix_unmatching_tags(self):
-        first_elem = list(VC('')._error_strings.keys())[0]
+        first_elem = list(VC._error_strings.keys())[0]
         self.doc = re.sub("<value>", "<value>" + first_elem, self.doc, count=1)
         file = io.StringIO(unicode(self.doc))
         with self.assertRaises(Exception):
             ET.fromstring(file.getvalue())
-        file = VC('')._fix_unmatching_tags(file)
+        file = VC(file)._fix_unmatching_tags()
         with self.assertNotRaises(Exception):
             ET.fromstring(file.getvalue())
 
     def test_convert_odml_file(self):
-        self.assertEqual(VC('').convert_odml_file("/not_valid_path"), None)
+        self.assertEqual(VC("/not_valid_path").convert_odml_file(), None)
         root = ET.fromstring(self.doc)
         prop = root.find("section").find("property")
         val_elems = []
@@ -107,7 +107,7 @@ class TestVersionConverter(unittest.TestCase):
         self.assertEqual(prop.find("type"), None)
 
         file = io.StringIO(unicode(self.doc))
-        tree = VC('').convert_odml_file(file)
+        tree = VC(file).convert_odml_file()
         root = tree.getroot()
         prop = root.find("section").find("property")
         val_elems = []
@@ -150,7 +150,7 @@ class TestVersionConverter(unittest.TestCase):
         """
 
         file = io.StringIO(unicode(doc))
-        conv_doc = VC('').convert_odml_file(file)
+        conv_doc = VC(file).convert_odml_file()
         root = conv_doc.getroot()
         # Test export of Document tags
         self.assertEqual(len(root.findall("author")), 1)
@@ -207,7 +207,7 @@ class TestVersionConverter(unittest.TestCase):
         """
 
         file = io.StringIO(unicode(doc))
-        conv_doc = VC('').convert_odml_file(file)
+        conv_doc = VC(file).convert_odml_file()
         root = conv_doc.getroot()
 
         sec = root.findall("section")
@@ -275,7 +275,7 @@ class TestVersionConverter(unittest.TestCase):
         """
 
         file = io.StringIO(unicode(doc))
-        conv_doc = VC('').convert_odml_file(file)
+        conv_doc = VC(file).convert_odml_file()
         root = conv_doc.getroot()
         sec = root.findall("section")
 
@@ -377,7 +377,7 @@ class TestVersionConverter(unittest.TestCase):
         """
 
         file = io.StringIO(unicode(doc))
-        conv_doc = VC('').convert_odml_file(file)
+        conv_doc = VC(file).convert_odml_file()
         root = conv_doc.getroot()
         sec = root.find("section")
         self.assertEqual(len(sec), 7)

--- a/test/test_version_converter.py
+++ b/test/test_version_converter.py
@@ -90,7 +90,7 @@ class TestVersionConverter(unittest.TestCase):
 
     def test_convert_odml_file(self):
         with self.assertRaises(Exception) as exc:
-            VC("/not_valid_path")._convert()
+            VC("/not_valid_path").convert()
         self.assertIn("Cannot parse provided file", str(exc.exception))
 
         root = ET.fromstring(self.doc)
@@ -106,7 +106,8 @@ class TestVersionConverter(unittest.TestCase):
         self.assertEqual(prop.find("type"), None)
 
         file = io.StringIO(unicode(self.doc))
-        tree = VC(file)._convert()
+        vc = VC(file)
+        tree = vc._convert(vc._parse_xml())
         root = tree.getroot()
         prop = root.find("section").find("property")
         val_elems = []
@@ -172,7 +173,8 @@ class TestVersionConverter(unittest.TestCase):
         """ % local_old_url
 
         file = io.StringIO(unicode(doc))
-        conv_doc = VC(file)._convert()
+        vc = VC(file)
+        conv_doc = vc._convert(vc._parse_xml())
         root = conv_doc.getroot()
         # Test export of Document tags, repository is excluded
         self.assertEqual(len(root.findall("author")), 1)
@@ -187,13 +189,15 @@ class TestVersionConverter(unittest.TestCase):
 
         # Test absence of non-importable repository
         file = io.StringIO(unicode(invalid_repo_doc))
-        conv_doc = VC(file)._convert()
+        vc = VC(file)
+        conv_doc = vc._convert(vc._parse_xml())
         root = conv_doc.getroot()
         self.assertEqual(len(root.findall("repository")), 0)
 
         # Test absence of old repository
         file = io.StringIO(unicode(old_repo_doc))
-        conv_doc = VC(file)._convert()
+        vc = VC(file)
+        conv_doc = vc._convert(vc._parse_xml())
         root = conv_doc.getroot()
         self.assertEqual(len(root.findall("repository")), 0)
 
@@ -256,7 +260,8 @@ class TestVersionConverter(unittest.TestCase):
         """ % (local_url, local_url, local_old_url)
 
         file = io.StringIO(unicode(doc))
-        conv_doc = VC(file)._convert()
+        vc = VC(file)
+        conv_doc = vc._convert(vc._parse_xml())
         root = conv_doc.getroot()
 
         sec = root.findall("section")
@@ -328,7 +333,8 @@ class TestVersionConverter(unittest.TestCase):
         """
 
         file = io.StringIO(unicode(doc))
-        conv_doc = VC(file)._convert()
+        vc = VC(file)
+        conv_doc = vc._convert(vc._parse_xml())
         root = conv_doc.getroot()
         sec = root.findall("section")
 
@@ -430,7 +436,8 @@ class TestVersionConverter(unittest.TestCase):
         """
 
         file = io.StringIO(unicode(doc))
-        conv_doc = VC(file)._convert()
+        vc = VC(file)
+        conv_doc = vc._convert(vc._parse_xml())
         root = conv_doc.getroot()
         sec = root.find("section")
         self.assertEqual(len(sec), 7)

--- a/test/test_version_converter.py
+++ b/test/test_version_converter.py
@@ -82,16 +82,6 @@ class TestVersionConverter(unittest.TestCase):
         self.assertEqual(props_names[0], "prop_name")
         self.assertEqual(props_names[1], "prop_name-2")
 
-    def test_fix_unmatching_tags(self):
-        first_elem = list(VC._error_strings.keys())[0]
-        self.doc = re.sub("<value>", "<value>" + first_elem, self.doc, count=1)
-        file = io.StringIO(unicode(self.doc))
-        with self.assertRaises(Exception):
-            ET.fromstring(file.getvalue())
-        file = VC(file)._fix_unmatching_tags()
-        with self.assertNotRaises(Exception):
-            ET.fromstring(file.getvalue())
-
     def test_convert_odml_file(self):
         with self.assertRaises(Exception) as exc:
             VC("/not_valid_path").convert_odml_file()

--- a/test/test_version_converter.py
+++ b/test/test_version_converter.py
@@ -187,19 +187,21 @@ class TestVersionConverter(unittest.TestCase):
         self.assertEqual(len(root.findall("property")), 0)
         self.assertEqual(len(root.findall("value")), 0)
 
-        # Test absence of non-importable repository
+        # Test warning message on non-importable repository
         file = io.StringIO(unicode(invalid_repo_doc))
         vc = VC(file)
         conv_doc = vc._convert(vc._parse_xml())
         root = conv_doc.getroot()
-        self.assertEqual(len(root.findall("repository")), 0)
+        self.assertEqual(root.findall("repository")[0].text, "Unresolvable")
+        self.assertIn("not odML v1.1 compatible", vc.conversion_log[0])
 
-        # Test absence of old repository
+        # Test warning message on old repository
         file = io.StringIO(unicode(old_repo_doc))
         vc = VC(file)
         conv_doc = vc._convert(vc._parse_xml())
         root = conv_doc.getroot()
-        self.assertEqual(len(root.findall("repository")), 0)
+        self.assertEqual(root.findall("repository")[0].text, local_old_url)
+        self.assertIn("not odML v1.1 compatible", vc.conversion_log[0])
 
     def test_convert_odml_file_section(self):
         """Test proper conversion of the odml.Section entity from
@@ -249,7 +251,6 @@ class TestVersionConverter(unittest.TestCase):
                     <invalid>Invalid tag</invalid>
                     <value>Invalid Value tag</value>
                     <mapping>Unsupported mapping tag</mapping>
-                    <repository>Unsupported section repository</repository>
                   </section>
                 
                   <section>
@@ -295,9 +296,8 @@ class TestVersionConverter(unittest.TestCase):
         self.assertEqual(len(sec[1]), 1)
         self.assertEqual(len(sec[1].findall("name")), 1)
 
-        # Test absence of v1.0 repository tag
-        self.assertEqual(len(sec[2]), 1)
-        self.assertEqual(len(sec[2].findall("name")), 1)
+        # Test presence of v1.0 repository tag
+        self.assertEqual(sec[2].find("repository").text, local_old_url)
 
     def test_convert_odml_file_property(self):
         """Test proper conversion of the odml.Property entity from

--- a/test/test_version_converter.py
+++ b/test/test_version_converter.py
@@ -90,7 +90,7 @@ class TestVersionConverter(unittest.TestCase):
 
     def test_convert_odml_file(self):
         with self.assertRaises(Exception) as exc:
-            VC("/not_valid_path").convert_odml_file()
+            VC("/not_valid_path")._convert()
         self.assertIn("Cannot parse provided file", str(exc.exception))
 
         root = ET.fromstring(self.doc)
@@ -106,7 +106,7 @@ class TestVersionConverter(unittest.TestCase):
         self.assertEqual(prop.find("type"), None)
 
         file = io.StringIO(unicode(self.doc))
-        tree = VC(file).convert_odml_file()
+        tree = VC(file)._convert()
         root = tree.getroot()
         prop = root.find("section").find("property")
         val_elems = []
@@ -172,7 +172,7 @@ class TestVersionConverter(unittest.TestCase):
         """ % local_old_url
 
         file = io.StringIO(unicode(doc))
-        conv_doc = VC(file).convert_odml_file()
+        conv_doc = VC(file)._convert()
         root = conv_doc.getroot()
         # Test export of Document tags, repository is excluded
         self.assertEqual(len(root.findall("author")), 1)
@@ -187,13 +187,13 @@ class TestVersionConverter(unittest.TestCase):
 
         # Test absence of non-importable repository
         file = io.StringIO(unicode(invalid_repo_doc))
-        conv_doc = VC(file).convert_odml_file()
+        conv_doc = VC(file)._convert()
         root = conv_doc.getroot()
         self.assertEqual(len(root.findall("repository")), 0)
 
         # Test absence of old repository
         file = io.StringIO(unicode(old_repo_doc))
-        conv_doc = VC(file).convert_odml_file()
+        conv_doc = VC(file)._convert()
         root = conv_doc.getroot()
         self.assertEqual(len(root.findall("repository")), 0)
 
@@ -256,7 +256,7 @@ class TestVersionConverter(unittest.TestCase):
         """ % (local_url, local_url, local_old_url)
 
         file = io.StringIO(unicode(doc))
-        conv_doc = VC(file).convert_odml_file()
+        conv_doc = VC(file)._convert()
         root = conv_doc.getroot()
 
         sec = root.findall("section")
@@ -328,7 +328,7 @@ class TestVersionConverter(unittest.TestCase):
         """
 
         file = io.StringIO(unicode(doc))
-        conv_doc = VC(file).convert_odml_file()
+        conv_doc = VC(file)._convert()
         root = conv_doc.getroot()
         sec = root.findall("section")
 
@@ -430,7 +430,7 @@ class TestVersionConverter(unittest.TestCase):
         """
 
         file = io.StringIO(unicode(doc))
-        conv_doc = VC(file).convert_odml_file()
+        conv_doc = VC(file)._convert()
         root = conv_doc.getroot()
         sec = root.find("section")
         self.assertEqual(len(sec), 7)

--- a/test/test_version_converter.py
+++ b/test/test_version_converter.py
@@ -145,10 +145,10 @@ class TestVersionConverter(unittest.TestCase):
         file = io.StringIO(unicode(doc))
         conv_doc = VC(file).convert_odml_file()
         root = conv_doc.getroot()
-        # Test export of Document tags
+        # Test export of Document tags, repository is excluded
         self.assertEqual(len(root.findall("author")), 1)
         self.assertEqual(len(root.findall("date")), 1)
-        self.assertEqual(len(root.findall("repository")), 1)
+        self.assertEqual(len(root.findall("repository")), 0)
         self.assertEqual(len(root.findall("section")), 1)
 
         # Test absence of non-Document tags
@@ -206,27 +206,27 @@ class TestVersionConverter(unittest.TestCase):
         sec = root.findall("section")
         self.assertEqual(len(sec), 2)
 
-        # Test valid section tags
-        self.assertEqual(len(sec[0]), 10)
+        # Test valid section tags, repository was excluded.
+        self.assertEqual(len(sec[0]), 9)
         self.assertEqual(sec[0].find("name").text, "Section name")
         self.assertEqual(sec[0].find("type").text, "Section type")
         self.assertEqual(sec[0].find("definition").text, "Section definition")
         self.assertEqual(sec[0].find("reference").text, "Section reference")
         self.assertEqual(sec[0].find("link").text, "Section link")
-        self.assertEqual(sec[0].find("repository").text, "Section repository")
+        # self.assertEqual(sec[0].find("repository").text, "Section repository")
         self.assertEqual(sec[0].find("include").text, "Section include")
         self.assertEqual(len(sec[0].findall("property")), 2)
         self.assertEqual(len(sec[0].findall("section")), 1)
 
-        # Test valid subsection tags
+        # Test valid subsection tags, repository was excluded.
         subsec = sec[0].find("section")
-        self.assertEqual(len(subsec), 8)
+        self.assertEqual(len(subsec), 7)
         self.assertEqual(subsec.find("name").text, "SubSection name")
         self.assertEqual(subsec.find("type").text, "SubSection type")
         self.assertEqual(subsec.find("definition").text, "SubSection definition")
         self.assertEqual(subsec.find("reference").text, "SubSection reference")
         self.assertEqual(subsec.find("link").text, "SubSection link")
-        self.assertEqual(subsec.find("repository").text, "SubSection repository")
+        # self.assertEqual(subsec.find("repository").text, "SubSection repository")
         self.assertEqual(subsec.find("include").text, "SubSection include")
         self.assertEqual(len(subsec.findall("property")), 1)
 

--- a/test/test_version_converter.py
+++ b/test/test_version_converter.py
@@ -93,7 +93,10 @@ class TestVersionConverter(unittest.TestCase):
             ET.fromstring(file.getvalue())
 
     def test_convert_odml_file(self):
-        self.assertEqual(VC("/not_valid_path").convert_odml_file(), None)
+        with self.assertRaises(Exception) as exc:
+            VC("/not_valid_path").convert_odml_file()
+        self.assertIn("Cannot parse provided file", str(exc.exception))
+
         root = ET.fromstring(self.doc)
         prop = root.find("section").find("property")
         val_elems = []


### PR DESCRIPTION
This PR refactors the odML version converter.

- Adds a conversion log for info and warning messages to the converter class. Closes #234.
- Includes the conversion of `dtype` and `dependency_value` on property level which was not supported so far.
- Introduces the conversion of JSON and YAML v1.0 files in addition to XML, which remains the default conversion type. Closes #218.
- Changes the main conversion method from `convert_odml_file()` to `convert()`. The conversion method now returns a unicode string that is immediately consumable by the `xmlparser` instead of an lxml ElementTree. Closes #231.
- Handles `repository` and `include` elements: changes v1.0 odml-terminology urls to their v1.1 counterparts. Closes  #216.
- Adds an `.xml` file extension on file saving if none was provided. Closes #217.
- The refactoring process also closes #230 and #232. The filename of the source file now only has to be given once when instantiating the converter. The source file is also no longer truncated and replaced when fixing mismatching XML tags but remains untouched.

In the process
- the `tools/__init__.py` was cleaned up to avoid import cycles.
- a new constant `REPOSITORY_BASE` was introduced to `terminology.py` to provide the base url of the g-node odml-terminology host.
