### PR TITLE
dtypes refactoring and various bugfixes!

### DIFF
--- a/odml/doc.py
+++ b/odml/doc.py
@@ -34,9 +34,12 @@ class BaseDocument(base.sectionable, Document):
             print(e)
             self._id = str(uuid.uuid4())
         self._author = author
-        self._date = date  # date must be a datetime
         self._version = version
         self._repository = repository
+
+        # Make sure date is properly parsed into a datetime object
+        self._date = None
+        self.date = date
 
     @property
     def id(self):

--- a/odml/dtypes.py
+++ b/odml/dtypes.py
@@ -119,8 +119,9 @@ def set(value, dtype=None):
 
 
 def int_get(string):
-    if not string:
+    if string is None or string == "":
         return default_values("int")
+
     try:
         return int(string)
     except ValueError:
@@ -129,16 +130,20 @@ def int_get(string):
 
 
 def float_get(string):
-    if not string:
+    if string is None or string == "":
         return default_values("float")
+
     return float(string)
 
 
 def str_get(string):
-    if not string:
+    # Do not stringify empty list or dict but make sure boolean False gets through.
+    if string in [None, "", [], {}]:
         return default_values("string")
+
     if sys.version_info < (3, 0):
         return unicode(string)
+
     return str(string)
 
 
@@ -150,8 +155,9 @@ string_set = str_get
 
 
 def time_get(string):
-    if not string:
+    if string is None or string == "":
         return default_values("time")
+
     if isinstance(string, dt.time):
         return dt.datetime.strptime(string.strftime(FORMAT_TIME), FORMAT_TIME).time()
 
@@ -162,8 +168,9 @@ time_set = time_get
 
 
 def date_get(string):
-    if not string:
+    if string is None or string == "":
         return default_values("date")
+
     if isinstance(string, dt.date):
         return dt.datetime.strptime(string.isoformat(), FORMAT_DATE).date()
 
@@ -174,8 +181,9 @@ date_set = date_get
 
 
 def datetime_get(string):
-    if not string:
+    if string is None or string == "":
         return default_values("datetime")
+
     if isinstance(string, dt.datetime):
         return dt.datetime.strptime(string.strftime(FORMAT_DATETIME), FORMAT_DATETIME)
 
@@ -186,16 +194,20 @@ datetime_set = datetime_get
 
 
 def boolean_get(string):
-    if not string:
+    if string in [None, "", [], {}]:
         return default_values("boolean")
+
     if isinstance(string, (unicode, str)):
         string = string.lower()
+
     truth = ["true", "1", True, "t"]  # be kind, spec only accepts True / False
     if string in truth:
         return True
+
     false = ["false", "0", False, "f"]
     if string in false:
         return False
+
     # disallow any values that cannot be interpreted as boolean.
     raise ValueError
 

--- a/odml/dtypes.py
+++ b/odml/dtypes.py
@@ -65,9 +65,9 @@ def infer_dtype(value):
         if dtype == 'string' and '\n' in value:
             dtype = 'text'
         return dtype
-    else:
-        # If unable to infer a dtype of given value, return defalt as *string*
-        return 'string'
+
+    # If unable to infer a dtype of given value, return default as *string*
+    return 'string'
 
 
 def valid_type(dtype):
@@ -149,10 +149,9 @@ def time_get(string):
     if not string:
         return default_values("time")
     if isinstance(string, datetime.time):
-        return datetime.datetime.strptime(string.strftime('%H:%M:%S'),
-                                          '%H:%M:%S').time()
-    else:
-        return datetime.datetime.strptime(string, '%H:%M:%S').time()
+        return datetime.datetime.strptime(string.strftime('%H:%M:%S'), '%H:%M:%S').time()
+
+    return datetime.datetime.strptime(string, '%H:%M:%S').time()
 
 
 def time_set(value):
@@ -160,6 +159,7 @@ def time_set(value):
         return default_values("time")
     if isinstance(value, datetime.time):
         return value.strftime("%H:%M:%S")
+
     return value.isoformat()
 
 
@@ -167,10 +167,9 @@ def date_get(string):
     if not string:
         return default_values("date")
     if isinstance(string, datetime.date):
-        return datetime.datetime.strptime(string.isoformat(),
-                                          '%Y-%m-%d').date()
-    else:
-        return datetime.datetime.strptime(string, '%Y-%m-%d').date()
+        return datetime.datetime.strptime(string.isoformat(), '%Y-%m-%d').date()
+
+    return datetime.datetime.strptime(string, '%Y-%m-%d').date()
 
 
 date_set = time_set
@@ -182,8 +181,7 @@ def datetime_get(string):
     if isinstance(string, datetime.datetime):
         return datetime.datetime.strptime(string.strftime('%Y-%m-%d %H:%M:%S'),
                                           '%Y-%m-%d %H:%M:%S')
-    else:
-        return datetime.datetime.strptime(string, '%Y-%m-%d %H:%M:%S')
+    return datetime.datetime.strptime(string, '%Y-%m-%d %H:%M:%S')
 
 
 def datetime_set(value):
@@ -191,8 +189,8 @@ def datetime_set(value):
         return default_values("datetime")
     if isinstance(value, datetime.datetime):
         return value.strftime('%Y-%m-%d %H:%M:%S')
-    else:
-        return datetime.datetime.strptime(value, '%Y-%m-%d %H:%M:%S')
+
+    return datetime.datetime.strptime(value, '%Y-%m-%d %H:%M:%S')
 
 
 def boolean_get(string):

--- a/odml/dtypes.py
+++ b/odml/dtypes.py
@@ -12,6 +12,10 @@ try:
 except NameError:
     unicode = str
 
+FORMAT_DATE = "%Y-%m-%d"
+FORMAT_DATETIME = "%Y-%m-%d %H:%M:%S"
+FORMAT_TIME = "%H:%M:%S"
+
 
 class DType(str, Enum):
     string = 'string'
@@ -44,11 +48,11 @@ def default_values(dtype):
         return default_dtype_value[dtype]
 
     if dtype == 'datetime':
-        return datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+        return datetime.datetime.now().strftime(FORMAT_DATETIME)
     if dtype == 'date':
-        return datetime.datetime.now().strftime('%Y-%m-%d')
+        return datetime.datetime.now().strftime(FORMAT_DATE)
     if dtype == 'time':
-        return datetime.datetime.now().strftime('%H:%M:%S')
+        return datetime.datetime.now().strftime(FORMAT_TIME)
 
     return ''  # Maybe return None ?
 
@@ -149,16 +153,16 @@ def time_get(string):
     if not string:
         return default_values("time")
     if isinstance(string, datetime.time):
-        return datetime.datetime.strptime(string.strftime('%H:%M:%S'), '%H:%M:%S').time()
+        return datetime.datetime.strptime(string.strftime(FORMAT_TIME), FORMAT_TIME).time()
 
-    return datetime.datetime.strptime(string, '%H:%M:%S').time()
+    return datetime.datetime.strptime(string, FORMAT_TIME).time()
 
 
 def time_set(value):
     if not value:
         return default_values("time")
     if isinstance(value, datetime.time):
-        return value.strftime("%H:%M:%S")
+        return value.strftime(FORMAT_TIME)
 
     return value.isoformat()
 
@@ -167,16 +171,16 @@ def date_get(string):
     if not string:
         return default_values("date")
     if isinstance(string, datetime.date):
-        return datetime.datetime.strptime(string.isoformat(), '%Y-%m-%d').date()
+        return datetime.datetime.strptime(string.isoformat(), FORMAT_DATE).date()
 
-    return datetime.datetime.strptime(string, '%Y-%m-%d').date()
+    return datetime.datetime.strptime(string, FORMAT_DATE).date()
 
 
 def date_set(value):
     if not value:
         return default_values("date")
     if isinstance(value, datetime.date):
-        return value.strftime('%Y-%m-%d')
+        return value.strftime(FORMAT_DATE)
 
     return value.isoformat()
 
@@ -185,18 +189,18 @@ def datetime_get(string):
     if not string:
         return default_values("datetime")
     if isinstance(string, datetime.datetime):
-        return datetime.datetime.strptime(string.strftime('%Y-%m-%d %H:%M:%S'),
-                                          '%Y-%m-%d %H:%M:%S')
-    return datetime.datetime.strptime(string, '%Y-%m-%d %H:%M:%S')
+        return datetime.datetime.strptime(string.strftime(FORMAT_DATETIME),
+                                          FORMAT_DATETIME)
+    return datetime.datetime.strptime(string, FORMAT_DATETIME)
 
 
 def datetime_set(value):
     if not value:
         return default_values("datetime")
     if isinstance(value, datetime.datetime):
-        return value.strftime('%Y-%m-%d %H:%M:%S')
+        return value.strftime(FORMAT_DATETIME)
 
-    return datetime.datetime.strptime(value, '%Y-%m-%d %H:%M:%S')
+    return datetime.datetime.strptime(value, FORMAT_DATETIME)
 
 
 def boolean_get(string):

--- a/odml/dtypes.py
+++ b/odml/dtypes.py
@@ -172,7 +172,13 @@ def date_get(string):
     return datetime.datetime.strptime(string, '%Y-%m-%d').date()
 
 
-date_set = time_set
+def date_set(value):
+    if not value:
+        return default_values("date")
+    if isinstance(value, datetime.date):
+        return value.strftime('%Y-%m-%d')
+
+    return value.isoformat()
 
 
 def datetime_get(string):

--- a/odml/dtypes.py
+++ b/odml/dtypes.py
@@ -1,5 +1,5 @@
 import sys
-import datetime
+import datetime as dt
 from enum import Enum
 self = sys.modules[__name__].__dict__
 
@@ -48,11 +48,11 @@ def default_values(dtype):
         return default_dtype_value[dtype]
 
     if dtype == 'datetime':
-        return datetime.datetime.now().replace(microsecond=0)
+        return dt.datetime.now().replace(microsecond=0)
     if dtype == 'date':
-        return datetime.datetime.now().date()
+        return dt.datetime.now().date()
     if dtype == 'time':
-        return datetime.datetime.now().replace(microsecond=0).time()
+        return dt.datetime.now().replace(microsecond=0).time()
 
     return ''  # Maybe return None ?
 
@@ -152,10 +152,10 @@ string_set = str_get
 def time_get(string):
     if not string:
         return default_values("time")
-    if isinstance(string, datetime.time):
-        return datetime.datetime.strptime(string.strftime(FORMAT_TIME), FORMAT_TIME).time()
+    if isinstance(string, dt.time):
+        return dt.datetime.strptime(string.strftime(FORMAT_TIME), FORMAT_TIME).time()
 
-    return datetime.datetime.strptime(string, FORMAT_TIME).time()
+    return dt.datetime.strptime(string, FORMAT_TIME).time()
 
 
 time_set = time_get
@@ -164,10 +164,10 @@ time_set = time_get
 def date_get(string):
     if not string:
         return default_values("date")
-    if isinstance(string, datetime.date):
-        return datetime.datetime.strptime(string.isoformat(), FORMAT_DATE).date()
+    if isinstance(string, dt.date):
+        return dt.datetime.strptime(string.isoformat(), FORMAT_DATE).date()
 
-    return datetime.datetime.strptime(string, FORMAT_DATE).date()
+    return dt.datetime.strptime(string, FORMAT_DATE).date()
 
 
 date_set = date_get
@@ -176,10 +176,10 @@ date_set = date_get
 def datetime_get(string):
     if not string:
         return default_values("datetime")
-    if isinstance(string, datetime.datetime):
-        return datetime.datetime.strptime(string.strftime(FORMAT_DATETIME),
-                                          FORMAT_DATETIME)
-    return datetime.datetime.strptime(string, FORMAT_DATETIME)
+    if isinstance(string, dt.datetime):
+        return dt.datetime.strptime(string.strftime(FORMAT_DATETIME), FORMAT_DATETIME)
+
+    return dt.datetime.strptime(string, FORMAT_DATETIME)
 
 
 datetime_set = datetime_get

--- a/odml/dtypes.py
+++ b/odml/dtypes.py
@@ -116,7 +116,7 @@ def set(value, dtype=None):
 
 def int_get(string):
     if not string:
-        return 0
+        return default_values("int")
     try:
         return int(string)
     except ValueError:
@@ -126,7 +126,7 @@ def int_get(string):
 
 def float_get(string):
     if not string:
-        return 0.0
+        return default_values("float")
     return float(string)
 
 

--- a/odml/dtypes.py
+++ b/odml/dtypes.py
@@ -48,11 +48,11 @@ def default_values(dtype):
         return default_dtype_value[dtype]
 
     if dtype == 'datetime':
-        return datetime.datetime.now().strftime(FORMAT_DATETIME)
+        return datetime.datetime.now().replace(microsecond=0)
     if dtype == 'date':
-        return datetime.datetime.now().strftime(FORMAT_DATE)
+        return datetime.datetime.now().date()
     if dtype == 'time':
-        return datetime.datetime.now().strftime(FORMAT_TIME)
+        return datetime.datetime.now().replace(microsecond=0).time()
 
     return ''  # Maybe return None ?
 

--- a/odml/dtypes.py
+++ b/odml/dtypes.py
@@ -131,6 +131,8 @@ def float_get(string):
 
 
 def str_get(string):
+    if not string:
+        return default_values("string")
     if sys.version_info < (3, 0):
         return unicode(string)
     return str(string)
@@ -145,7 +147,7 @@ string_set = str_get
 
 def time_get(string):
     if not string:
-        return None
+        return default_values("time")
     if type(string) is datetime.time:
         return datetime.datetime.strptime(string.strftime('%H:%M:%S'),
                                           '%H:%M:%S').time()
@@ -155,7 +157,7 @@ def time_get(string):
 
 def time_set(value):
     if not value:
-        return None
+        return default_values("time")
     if type(value) is datetime.time:
         return value.strftime("%H:%M:%S")
     return value.isoformat()
@@ -163,7 +165,7 @@ def time_set(value):
 
 def date_get(string):
     if not string:
-        return None
+        return default_values("date")
     if type(string) is datetime.date:
         return datetime.datetime.strptime(string.isoformat(),
                                           '%Y-%m-%d').date()
@@ -176,7 +178,7 @@ date_set = time_set
 
 def datetime_get(string):
     if not string:
-        return None
+        return default_values("datetime")
     if type(string) is datetime.datetime:
         return datetime.datetime.strptime(string.strftime('%Y-%m-%d %H:%M:%S'),
                                           '%Y-%m-%d %H:%M:%S')
@@ -186,7 +188,7 @@ def datetime_get(string):
 
 def datetime_set(value):
     if not value:
-        return None
+        return default_values("datetime")
     if type(value) is datetime.datetime:
         return value.strftime('%Y-%m-%d %H:%M:%S')
     else:
@@ -194,8 +196,8 @@ def datetime_set(value):
 
 
 def boolean_get(string):
-    if string is None:
-        return None
+    if not string:
+        return default_values("boolean")
     if type(string) in (unicode, str):
         string = string.lower()
     truth = ["true", "1", True, "t"]  # be kind, spec only accepts True / False
@@ -208,6 +210,7 @@ def boolean_get(string):
     raise ValueError
 
 # Alias boolean_set to boolean_get. Both perform same function.
+
 
 boolean_set = boolean_get
 bool_get = boolean_get

--- a/odml/dtypes.py
+++ b/odml/dtypes.py
@@ -158,13 +158,7 @@ def time_get(string):
     return datetime.datetime.strptime(string, FORMAT_TIME).time()
 
 
-def time_set(value):
-    if not value:
-        return default_values("time")
-    if isinstance(value, datetime.time):
-        return value.strftime(FORMAT_TIME)
-
-    return value.isoformat()
+time_set = time_get
 
 
 def date_get(string):
@@ -176,13 +170,7 @@ def date_get(string):
     return datetime.datetime.strptime(string, FORMAT_DATE).date()
 
 
-def date_set(value):
-    if not value:
-        return default_values("date")
-    if isinstance(value, datetime.date):
-        return value.strftime(FORMAT_DATE)
-
-    return value.isoformat()
+date_set = date_get
 
 
 def datetime_get(string):
@@ -194,13 +182,7 @@ def datetime_get(string):
     return datetime.datetime.strptime(string, FORMAT_DATETIME)
 
 
-def datetime_set(value):
-    if not value:
-        return default_values("datetime")
-    if isinstance(value, datetime.datetime):
-        return value.strftime(FORMAT_DATETIME)
-
-    return datetime.datetime.strptime(value, FORMAT_DATETIME)
+datetime_set = datetime_get
 
 
 def boolean_get(string):

--- a/odml/dtypes.py
+++ b/odml/dtypes.py
@@ -109,7 +109,7 @@ def set(value, dtype=None):
         if isinstance(value, str):
             return str_set(value)
     else:
-        if type(value) in (str, unicode):
+        if isinstance(value, (str, unicode)):
             return str_set(value)
     return self.get(dtype + "_set", str_set)(value)
 
@@ -148,7 +148,7 @@ string_set = str_get
 def time_get(string):
     if not string:
         return default_values("time")
-    if type(string) is datetime.time:
+    if isinstance(string, datetime.time):
         return datetime.datetime.strptime(string.strftime('%H:%M:%S'),
                                           '%H:%M:%S').time()
     else:
@@ -158,7 +158,7 @@ def time_get(string):
 def time_set(value):
     if not value:
         return default_values("time")
-    if type(value) is datetime.time:
+    if isinstance(value, datetime.time):
         return value.strftime("%H:%M:%S")
     return value.isoformat()
 
@@ -166,7 +166,7 @@ def time_set(value):
 def date_get(string):
     if not string:
         return default_values("date")
-    if type(string) is datetime.date:
+    if isinstance(string, datetime.date):
         return datetime.datetime.strptime(string.isoformat(),
                                           '%Y-%m-%d').date()
     else:
@@ -179,7 +179,7 @@ date_set = time_set
 def datetime_get(string):
     if not string:
         return default_values("datetime")
-    if type(string) is datetime.datetime:
+    if isinstance(string, datetime.datetime):
         return datetime.datetime.strptime(string.strftime('%Y-%m-%d %H:%M:%S'),
                                           '%Y-%m-%d %H:%M:%S')
     else:
@@ -189,7 +189,7 @@ def datetime_get(string):
 def datetime_set(value):
     if not value:
         return default_values("datetime")
-    if type(value) is datetime.datetime:
+    if isinstance(value, datetime.datetime):
         return value.strftime('%Y-%m-%d %H:%M:%S')
     else:
         return datetime.datetime.strptime(value, '%Y-%m-%d %H:%M:%S')
@@ -198,7 +198,7 @@ def datetime_set(value):
 def boolean_get(string):
     if not string:
         return default_values("boolean")
-    if type(string) in (unicode, str):
+    if isinstance(string, (unicode, str)):
         string = string.lower()
     truth = ["true", "1", True, "t"]  # be kind, spec only accepts True / False
     if string in truth:

--- a/odml/tools/dict_parser.py
+++ b/odml/tools/dict_parser.py
@@ -184,17 +184,13 @@ class DictReader:
 
         for _property in props_list:
             prop_attrs = {}
-            values = []
 
             for i in _property:
                 attr = self.is_valid_attribute(i, odmlfmt.Property)
-                if attr == 'value':
-                    values = _property['value']
                 if attr:
                     prop_attrs[attr] = _property[attr]
 
             prop = odmlfmt.Property.create(**prop_attrs)
-            prop.value = values
             odml_props.append(prop)
 
         return odml_props

--- a/odml/tools/dict_parser.py
+++ b/odml/tools/dict_parser.py
@@ -83,7 +83,13 @@ class DictWriter:
                     if isinstance(tag, tuple):
                         prop_dict[attr] = list(tag)
                     elif (tag == []) or tag:  # Even if 'value' is empty, allow '[]'
-                        prop_dict[attr] = tag
+                        # Custom odML tuples require special handling
+                        # for save loading from file.
+                        if attr == "value" and prop.dtype and \
+                                prop.dtype.endswith("-tuple") and len(prop.value) > 0:
+                            prop_dict["value"] = "(%s)" % ";".join(prop.value[0])
+                        else:
+                            prop_dict[attr] = tag
 
             props_seq.append(prop_dict)
 

--- a/odml/tools/odmlparser.py
+++ b/odml/tools/odmlparser.py
@@ -5,6 +5,7 @@ A generic odML parsing module.
 Parses odML files and documents.
 """
 
+import datetime
 import json
 import yaml
 
@@ -67,9 +68,19 @@ class ODMLWriter:
             if self.parser == 'YAML':
                 string_doc = yaml.dump(odml_output, default_flow_style=False)
             elif self.parser == 'JSON':
-                string_doc = json.dumps(odml_output, indent=4)
+                string_doc = json.dumps(odml_output, indent=4,
+                                        cls=JSONDateTimeSerializer)
 
         return string_doc
+
+
+# Required to serialize datetime values with JSON.
+class JSONDateTimeSerializer(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, (datetime.datetime, datetime.date, datetime.time)):
+            return str(o)
+
+        return json.JSONEncoder.default(self, o)
 
 
 class ODMLReader:

--- a/odml/tools/xmlparser.py
+++ b/odml/tools/xmlparser.py
@@ -83,7 +83,11 @@ class XMLWriter:
             if val is None:
                 continue
             if isinstance(fmt, format.Property.__class__) and k == "value":
-                ele = E(k, to_csv(val))
+                # Custom odML tuples require special handling for save loading from file.
+                if e.dtype and e.dtype.endswith("-tuple") and len(val) > 0:
+                    ele = E(k, "(%s)" % ";".join(val[0]))
+                else:
+                    ele = E(k, to_csv(val))
                 cur.append(ele)
             else:
                 if isinstance(val, list):

--- a/test/test_dtypes.py
+++ b/test/test_dtypes.py
@@ -11,24 +11,40 @@ class TestTypes(unittest.TestCase):
         pass
 
     def test_date(self):
+        re = "^[0-9]{4}-(0[1-9]|1[0-2])-([0-2][0-9]|3[0-1])$"
+        self.assertRegexpMatches(typ.date_get(None), re)
+        self.assertRegexpMatches(typ.date_get(""), re)
+
         date = datetime.date(2011, 12, 1)
         date_string = '2011-12-01'
         self.assertEqual(date, typ.date_get(date_string))
         self.assertEqual(typ.date_set(date), date_string)
 
     def test_time(self):
+        re = "^[0-5][0-9]:[0-5][0-9]:[0-5][0-9]$"
+        self.assertRegexpMatches(typ.time_get(None), re)
+        self.assertRegexpMatches(typ.time_get(""), re)
+
         time = datetime.time(12, 34, 56)
         time_string = '12:34:56'
         self.assertEqual(time, typ.time_get(time_string))
         self.assertEqual(typ.time_set(time), time_string)
 
     def test_datetime(self):
+        re = "^[0-9]{4}-(0[1-9]|1[0-2])-([0-2][0-9]|3[0-1]) " \
+             "[0-5][0-9]:[0-5][0-9]:[0-5][0-9]$"
+        self.assertRegexpMatches(typ.datetime_get(None), re)
+        self.assertRegexpMatches(typ.datetime_get(""), re)
+
         date = datetime.datetime(2011, 12, 1, 12, 34, 56)
         date_string = '2011-12-01 12:34:56'
         self.assertEqual(date, typ.datetime_get(date_string))
         self.assertEqual(typ.datetime_set(date), date_string)
 
     def test_int(self):
+        self.assertEqual(typ.default_values("int"), typ.int_get(None))
+        self.assertEqual(typ.default_values("int"), typ.int_get(""))
+
         p = odml.Property("test", value="123456789012345678901", dtype="int")
         self.assertEqual(p.value[0], 123456789012345678901)
         p = odml.Property("test", value="-123456789012345678901", dtype="int")
@@ -37,6 +53,9 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(p.value[0], 123)
 
     def test_str(self):
+        self.assertEqual(typ.default_values("string"), typ.str_get(None))
+        self.assertEqual(typ.default_values("string"), typ.str_get(""))
+
         s = odml.Property(name='Name', value='Sherin')
         self.assertEqual(s.value[0], 'Sherin')
         self.assertEqual(s.dtype, 'string')
@@ -46,7 +65,8 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(s.dtype, 'string')
 
     def test_bool(self):
-        self.assertEqual(None, typ.boolean_get(None))
+        self.assertEqual(typ.default_values("boolean"), typ.boolean_get(None))
+        self.assertEqual(typ.default_values("boolean"), typ.boolean_get(""))
 
         true_values = [True, "TRUE", "true", "T", "t", "1", 1]
         for val in true_values:

--- a/test/test_dtypes.py
+++ b/test/test_dtypes.py
@@ -12,8 +12,8 @@ class TestTypes(unittest.TestCase):
 
     def test_date(self):
         re = "^[0-9]{4}-(0[1-9]|1[0-2])-([0-2][0-9]|3[0-1])$"
-        self.assertRegexpMatches(typ.date_get(None), re)
-        self.assertRegexpMatches(typ.date_get(""), re)
+        self.assertRegexpMatches(typ.date_get(None).strftime(typ.FORMAT_DATE), re)
+        self.assertRegexpMatches(typ.date_get("").strftime(typ.FORMAT_DATE), re)
 
         date = datetime.date(2011, 12, 1)
         date_string = '2011-12-01'
@@ -21,8 +21,8 @@ class TestTypes(unittest.TestCase):
 
     def test_time(self):
         re = "^[0-5][0-9]:[0-5][0-9]:[0-5][0-9]$"
-        self.assertRegexpMatches(typ.time_get(None), re)
-        self.assertRegexpMatches(typ.time_get(""), re)
+        self.assertRegexpMatches(typ.time_get(None).strftime(typ.FORMAT_TIME), re)
+        self.assertRegexpMatches(typ.time_get("").strftime(typ.FORMAT_TIME), re)
 
         time = datetime.time(12, 34, 56)
         time_string = '12:34:56'
@@ -31,8 +31,8 @@ class TestTypes(unittest.TestCase):
     def test_datetime(self):
         re = "^[0-9]{4}-(0[1-9]|1[0-2])-([0-2][0-9]|3[0-1]) " \
              "[0-5][0-9]:[0-5][0-9]:[0-5][0-9]$"
-        self.assertRegexpMatches(typ.datetime_get(None), re)
-        self.assertRegexpMatches(typ.datetime_get(""), re)
+        self.assertRegexpMatches(typ.datetime_get(None).strftime(typ.FORMAT_DATETIME), re)
+        self.assertRegexpMatches(typ.datetime_get("").strftime(typ.FORMAT_DATETIME), re)
 
         date = datetime.datetime(2011, 12, 1, 12, 34, 56)
         date_string = '2011-12-01 12:34:56'

--- a/test/test_dtypes.py
+++ b/test/test_dtypes.py
@@ -2,7 +2,6 @@ import datetime
 import unittest
 
 import odml.dtypes as typ
-import odml
 
 
 class TestTypes(unittest.TestCase):
@@ -111,12 +110,12 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(typ.default_values("int"), typ.int_get(None))
         self.assertEqual(typ.default_values("int"), typ.int_get(""))
 
-        p = odml.Property("test", value="123456789012345678901", dtype="int")
-        self.assertEqual(p.value[0], 123456789012345678901)
-        p = odml.Property("test", value="-123456789012345678901", dtype="int")
-        self.assertEqual(p.value[0], -123456789012345678901)
-        p = odml.Property("test", value="123.45", dtype="int")
-        self.assertEqual(p.value[0], 123)
+        self.assertIsInstance(typ.int_get(11), int)
+        self.assertIsInstance(typ.int_get(1.1), int)
+        self.assertIsInstance(typ.int_get("11"), int)
+        self.assertEqual(typ.int_get("123456789012345678901"), 123456789012345678901)
+        self.assertEqual(typ.int_get("-123456789012345678901"), -123456789012345678901)
+        self.assertEqual(typ.int_get("123.45"), 123)
 
         with self.assertRaises(TypeError):
             _ = typ.int_get([])
@@ -129,8 +128,9 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(typ.default_values("float"), typ.float_get(None))
         self.assertEqual(typ.default_values("float"), typ.float_get(""))
 
-        self.assertEqual(typ.float_get(123.45), 123.45)
         self.assertIsInstance(typ.float_get(1), float)
+        self.assertIsInstance(typ.float_get("1.1"), float)
+        self.assertEqual(typ.float_get(123.45), 123.45)
 
         with self.assertRaises(TypeError):
             _ = typ.float_get([])
@@ -148,14 +148,6 @@ class TestTypes(unittest.TestCase):
         # Make sure boolean values are properly converted to string.
         self.assertEqual(typ.str_get(False), 'False')
         self.assertEqual(typ.str_get(True), 'True')
-
-        s = odml.Property(name='Name', value='Sherin')
-        self.assertEqual(s.value[0], 'Sherin')
-        self.assertEqual(s.dtype, 'string')
-
-        s.value = 'Jerin'
-        self.assertEqual(s.value[0], 'Jerin')
-        self.assertEqual(s.dtype, 'string')
 
     def test_bool(self):
         self.assertEqual(typ.default_values("boolean"), typ.boolean_get(None))
@@ -179,18 +171,17 @@ class TestTypes(unittest.TestCase):
             typ.boolean_get(2.1)
 
     def test_tuple(self):
-        # Success test
-        t = odml.Property(name="Location", value='(39.12; 67.19)', dtype='2-tuple')
-        tuple_value = t.value[0]  # As the formed tuple is a list of list
-        self.assertEqual(tuple_value[0], '39.12')
-        self.assertEqual(tuple_value[1], '67.19')
+        self.assertIs(typ.tuple_get(""), None)
+        self.assertIs(typ.tuple_get(None), None)
 
-        # Failure test. More tuple values then specified.
-        with self.assertRaises(ValueError):
-            t = odml.Property(name="Public-Key", value='(5689; 1254; 687)',
-                              dtype='2-tuple')
+        self.assertEqual(typ.tuple_get("(39.12; 67.19)"), ["39.12", "67.19"])
+
+        # Test fail on missing parenthesis.
+        with self.assertRaises(AssertionError):
+            _ = typ.tuple_get("fail")
+        # Test fail on mismatching element count and count number.
+        with self.assertRaises(AssertionError):
+            _ = typ.tuple_get("(1; 2; 3)", 2)
 
     def test_dtype_none(self):
-        t = odml.Property(name="Record", value={'name': 'Marie'})
-        self.assertEqual(t.dtype, 'string')
-        self.assertEqual(t.value[0], "{'name': 'Marie'}")
+        self.assertEqual(typ.get({'name': 'Marie'}), "{'name': 'Marie'}")

--- a/test/test_dtypes.py
+++ b/test/test_dtypes.py
@@ -23,6 +23,18 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(date, typ.date_get(date_string))
         self.assertEqual(date, typ.date_get(date))
 
+        # Test fail on datetime.datetime
+        with self.assertRaises(ValueError):
+            _ = typ.date_get(datetime.datetime.now())
+
+        # Test fail on datetime.time
+        with self.assertRaises(TypeError):
+            _ = typ.date_get(datetime.datetime.now().time())
+
+        # Test fail on invalid string format
+        with self.assertRaises(ValueError):
+            _ = typ.date_get("11.11.1111")
+
     def test_time(self):
         self.assertIsInstance(typ.time_get(None), datetime.time)
         self.assertIsInstance(typ.time_get(""), datetime.time)
@@ -35,6 +47,18 @@ class TestTypes(unittest.TestCase):
         time_string = '12:34:56'
         self.assertEqual(time, typ.time_get(time_string))
         self.assertEqual(time, typ.time_get(time))
+
+        # Test fail on datetime.datetime
+        with self.assertRaises(TypeError):
+            _ = typ.time_get(datetime.datetime.now())
+
+        # Test fail on datetime.date
+        with self.assertRaises(TypeError):
+            _ = typ.time_get(datetime.datetime.now().date())
+
+        # Test fail on invalid string format
+        with self.assertRaises(ValueError):
+            _ = typ.time_get("11-11-11")
 
     def test_datetime(self):
         self.assertIsInstance(typ.datetime_get(None), datetime.datetime)
@@ -49,6 +73,18 @@ class TestTypes(unittest.TestCase):
         date_string = '2011-12-01 12:34:56'
         self.assertEqual(date, typ.datetime_get(date_string))
         self.assertEqual(date, typ.datetime_get(date))
+
+        # Test fail on datetime.time
+        with self.assertRaises(TypeError):
+            _ = typ.datetime_get(datetime.datetime.now().time())
+
+        # Test fail on datetime.date
+        with self.assertRaises(TypeError):
+            _ = typ.datetime_get(datetime.datetime.now().date())
+
+        # Test fail on invalid string format
+        with self.assertRaises(ValueError):
+            _ = typ.datetime_get("11.11.1111 12:12:12")
 
     def test_int(self):
         self.assertEqual(typ.default_values("int"), typ.int_get(None))

--- a/test/test_dtypes.py
+++ b/test/test_dtypes.py
@@ -97,6 +97,20 @@ class TestTypes(unittest.TestCase):
         p = odml.Property("test", value="123.45", dtype="int")
         self.assertEqual(p.value[0], 123)
 
+    def test_float(self):
+        self.assertEqual(typ.default_values("float"), typ.float_get(None))
+        self.assertEqual(typ.default_values("float"), typ.float_get(""))
+
+        self.assertEqual(typ.float_get(123.45), 123.45)
+        self.assertIsInstance(typ.float_get(1), float)
+
+        with self.assertRaises(TypeError):
+            _ = typ.float_get([])
+        with self.assertRaises(TypeError):
+            _ = typ.float_get({})
+        with self.assertRaises(ValueError):
+            _ = typ.float_get("fail")
+
     def test_str(self):
         self.assertEqual(typ.default_values("string"), typ.str_get(None))
         self.assertEqual(typ.default_values("string"), typ.str_get(""))

--- a/test/test_dtypes.py
+++ b/test/test_dtypes.py
@@ -11,6 +11,9 @@ class TestTypes(unittest.TestCase):
         pass
 
     def test_date(self):
+        self.assertIsInstance(typ.date_get(None), datetime.date)
+        self.assertIsInstance(typ.date_get(""), datetime.date)
+
         re = "^[0-9]{4}-(0[1-9]|1[0-2])-([0-2][0-9]|3[0-1])$"
         self.assertRegexpMatches(typ.date_get(None).strftime(typ.FORMAT_DATE), re)
         self.assertRegexpMatches(typ.date_get("").strftime(typ.FORMAT_DATE), re)
@@ -18,8 +21,12 @@ class TestTypes(unittest.TestCase):
         date = datetime.date(2011, 12, 1)
         date_string = '2011-12-01'
         self.assertEqual(date, typ.date_get(date_string))
+        self.assertEqual(date, typ.date_get(date))
 
     def test_time(self):
+        self.assertIsInstance(typ.time_get(None), datetime.time)
+        self.assertIsInstance(typ.time_get(""), datetime.time)
+
         re = "^[0-5][0-9]:[0-5][0-9]:[0-5][0-9]$"
         self.assertRegexpMatches(typ.time_get(None).strftime(typ.FORMAT_TIME), re)
         self.assertRegexpMatches(typ.time_get("").strftime(typ.FORMAT_TIME), re)
@@ -27,8 +34,12 @@ class TestTypes(unittest.TestCase):
         time = datetime.time(12, 34, 56)
         time_string = '12:34:56'
         self.assertEqual(time, typ.time_get(time_string))
+        self.assertEqual(time, typ.time_get(time))
 
     def test_datetime(self):
+        self.assertIsInstance(typ.datetime_get(None), datetime.datetime)
+        self.assertIsInstance(typ.datetime_get(""), datetime.datetime)
+
         re = "^[0-9]{4}-(0[1-9]|1[0-2])-([0-2][0-9]|3[0-1]) " \
              "[0-5][0-9]:[0-5][0-9]:[0-5][0-9]$"
         self.assertRegexpMatches(typ.datetime_get(None).strftime(typ.FORMAT_DATETIME), re)
@@ -37,6 +48,7 @@ class TestTypes(unittest.TestCase):
         date = datetime.datetime(2011, 12, 1, 12, 34, 56)
         date_string = '2011-12-01 12:34:56'
         self.assertEqual(date, typ.datetime_get(date_string))
+        self.assertEqual(date, typ.datetime_get(date))
 
     def test_int(self):
         self.assertEqual(typ.default_values("int"), typ.int_get(None))

--- a/test/test_dtypes.py
+++ b/test/test_dtypes.py
@@ -18,7 +18,6 @@ class TestTypes(unittest.TestCase):
         date = datetime.date(2011, 12, 1)
         date_string = '2011-12-01'
         self.assertEqual(date, typ.date_get(date_string))
-        self.assertEqual(typ.date_set(date), date_string)
 
     def test_time(self):
         re = "^[0-5][0-9]:[0-5][0-9]:[0-5][0-9]$"
@@ -28,7 +27,6 @@ class TestTypes(unittest.TestCase):
         time = datetime.time(12, 34, 56)
         time_string = '12:34:56'
         self.assertEqual(time, typ.time_get(time_string))
-        self.assertEqual(typ.time_set(time), time_string)
 
     def test_datetime(self):
         re = "^[0-9]{4}-(0[1-9]|1[0-2])-([0-2][0-9]|3[0-1]) " \
@@ -39,7 +37,6 @@ class TestTypes(unittest.TestCase):
         date = datetime.datetime(2011, 12, 1, 12, 34, 56)
         date_string = '2011-12-01 12:34:56'
         self.assertEqual(date, typ.datetime_get(date_string))
-        self.assertEqual(typ.datetime_set(date), date_string)
 
     def test_int(self):
         self.assertEqual(typ.default_values("int"), typ.int_get(None))

--- a/test/test_dtypes.py
+++ b/test/test_dtypes.py
@@ -1,8 +1,8 @@
+import datetime
 import unittest
 
 import odml.dtypes as typ
 import odml
-import datetime
 
 
 class TestTypes(unittest.TestCase):
@@ -22,6 +22,13 @@ class TestTypes(unittest.TestCase):
         date_string = '2011-12-01'
         self.assertEqual(date, typ.date_get(date_string))
         self.assertEqual(date, typ.date_get(date))
+
+        with self.assertRaises(TypeError):
+            _ = typ.date_get([])
+        with self.assertRaises(TypeError):
+            _ = typ.date_get({})
+        with self.assertRaises(TypeError):
+            _ = typ.date_get(False)
 
         # Test fail on datetime.datetime
         with self.assertRaises(ValueError):
@@ -47,6 +54,13 @@ class TestTypes(unittest.TestCase):
         time_string = '12:34:56'
         self.assertEqual(time, typ.time_get(time_string))
         self.assertEqual(time, typ.time_get(time))
+
+        with self.assertRaises(TypeError):
+            _ = typ.time_get([])
+        with self.assertRaises(TypeError):
+            _ = typ.time_get({})
+        with self.assertRaises(TypeError):
+            _ = typ.time_get(False)
 
         # Test fail on datetime.datetime
         with self.assertRaises(TypeError):
@@ -74,6 +88,13 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(date, typ.datetime_get(date_string))
         self.assertEqual(date, typ.datetime_get(date))
 
+        with self.assertRaises(TypeError):
+            _ = typ.datetime_get([])
+        with self.assertRaises(TypeError):
+            _ = typ.datetime_get({})
+        with self.assertRaises(TypeError):
+            _ = typ.datetime_get(False)
+
         # Test fail on datetime.time
         with self.assertRaises(TypeError):
             _ = typ.datetime_get(datetime.datetime.now().time())
@@ -97,6 +118,13 @@ class TestTypes(unittest.TestCase):
         p = odml.Property("test", value="123.45", dtype="int")
         self.assertEqual(p.value[0], 123)
 
+        with self.assertRaises(TypeError):
+            _ = typ.int_get([])
+        with self.assertRaises(TypeError):
+            _ = typ.int_get({})
+        with self.assertRaises(ValueError):
+            _ = typ.int_get("fail")
+
     def test_float(self):
         self.assertEqual(typ.default_values("float"), typ.float_get(None))
         self.assertEqual(typ.default_values("float"), typ.float_get(""))
@@ -114,6 +142,12 @@ class TestTypes(unittest.TestCase):
     def test_str(self):
         self.assertEqual(typ.default_values("string"), typ.str_get(None))
         self.assertEqual(typ.default_values("string"), typ.str_get(""))
+        self.assertEqual(typ.default_values("string"), typ.str_get([]))
+        self.assertEqual(typ.default_values("string"), typ.str_get({}))
+
+        # Make sure boolean values are properly converted to string.
+        self.assertEqual(typ.str_get(False), 'False')
+        self.assertEqual(typ.str_get(True), 'True')
 
         s = odml.Property(name='Name', value='Sherin')
         self.assertEqual(s.value[0], 'Sherin')
@@ -126,6 +160,8 @@ class TestTypes(unittest.TestCase):
     def test_bool(self):
         self.assertEqual(typ.default_values("boolean"), typ.boolean_get(None))
         self.assertEqual(typ.default_values("boolean"), typ.boolean_get(""))
+        self.assertEqual(typ.default_values("boolean"), typ.boolean_get([]))
+        self.assertEqual(typ.default_values("boolean"), typ.boolean_get({}))
 
         true_values = [True, "TRUE", "true", "T", "t", "1", 1]
         for val in true_values:

--- a/test/test_infer_type.py
+++ b/test/test_infer_type.py
@@ -11,51 +11,51 @@ class TestInferType(unittest.TestCase):
         p = Property("test", value="somestring")
         assert(p.dtype == "string")
         if sys.version_info < (3, 0):
-            assert (type(p.value[0]) == unicode)
+            assert isinstance(p.value[0], unicode)
         else:
-            assert (type(p.value[0]) == str)
+            assert isinstance(p.value[0], str)
 
     def test_text(self):
         p = Property("test", value="some\nstring")
         assert(p.dtype == "text")
         if sys.version_info < (3, 0):
-            assert (type(p.value[0]) == unicode)
+            assert isinstance(p.value[0], unicode)
         else:
-            assert (type(p.value[0]) == str)
+            assert isinstance(p.value[0], str)
 
     def test_int(self):
         p = Property("test", value=111)
         assert(p.dtype == "int")
-        assert(type(p.value[0]) == int)
+        assert isinstance(p.value[0], int)
 
     def test_float(self):
         p = Property("test", value=3.14)
         assert(p.dtype == "float")
-        assert(type(p.value[0]) == float)
+        assert isinstance(p.value[0], float)
 
     def test_datetime(self):
         p = Property("test", value=dt.now())
         assert(p.dtype == "datetime")
-        assert(type(p.value[0]) == dt)
+        assert isinstance(p.value[0], dt)
 
     def test_date(self):
         p = Property("test", dt.now().date())
         assert(p.dtype == "date")
-        assert(type(p.value[0]) == date)
+        assert isinstance(p.value[0], date)
 
     def test_time(self):
         p = Property("test", value=dt.now().time())
         assert(p.dtype == "time")
-        assert(type(p.value[0]) == time)
+        assert isinstance(p.value[0], time)
 
     def test_boolean(self):
         p = Property("test", True)
         assert(p.dtype == "boolean")
-        assert(type(p.value[0]) == bool)
+        assert isinstance(p.value[0], bool)
 
         p = Property("test", False)
         assert(p.dtype == "boolean")
-        assert(type(p.value[0]) == bool)
+        assert isinstance(p.value[0], bool)
 
     def test_read_write(self):
         doc = Document("author")
@@ -79,37 +79,37 @@ class TestInferType(unittest.TestCase):
         p = new_sec.properties["strprop"]
         assert(p.dtype == "string")
         if sys.version_info < (3, 0):
-            assert(type(p.value[0]) == unicode)
+            assert isinstance(p.value[0], unicode)
         else:
-            assert(type(p.value[0]) == str)
+            assert isinstance(p.value[0], str)
 
         p = new_sec.properties["txtprop"]
         assert(p.dtype == "text")
         if sys.version_info < (3, 0):
-            assert(type(p.value[0]) == unicode)
+            assert isinstance(p.value[0], unicode)
         else:
-            assert(type(p.value[0]) == str)
+            assert isinstance(p.value[0], str)
 
         p = new_sec.properties["intprop"]
         assert(p.dtype == "int")
-        assert(type(p.value[0]) == int)
+        assert isinstance(p.value[0], int)
 
         p = new_sec.properties["floatprop"]
         assert(p.dtype == "float")
-        assert(type(p.value[0]) == float)
+        assert isinstance(p.value[0], float)
 
         p = new_sec.properties["datetimeprop"]
         assert(p.dtype == "datetime")
-        assert(type(p.value[0]) == dt)
+        assert isinstance(p.value[0], dt)
 
         p = new_sec.properties["dateprop"]
         assert(p.dtype == "date")
-        assert(type(p.value[0]) == date)
+        assert isinstance(p.value[0], date)
 
         p = new_sec.properties["timeprop"]
         assert(p.dtype == "time")
-        assert(type(p.value[0]) == time)
+        assert isinstance(p.value[0], time)
 
         p = new_sec.properties["boolprop"]
         assert(p.dtype == "boolean")
-        assert(type(p.value[0]) == bool)
+        assert isinstance(p.value[0], bool)

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -73,6 +73,24 @@ class TestProperty(unittest.TestCase):
         p6 = Property("test", {"name": "Marie", "name":"Johanna"})
         self.assertEqual(len(p6), 1)
 
+        # Test tuple dtype value.
+        t = Property(name="Location", value='(39.12; 67.19)', dtype='2-tuple')
+        tuple_value = t.value[0]  # As the formed tuple is a list of list
+        self.assertEqual(tuple_value[0], '39.12')
+        self.assertEqual(tuple_value[1], '67.19')
+
+        # Test invalid tuple length
+        with self.assertRaises(ValueError):
+            _ = Property(name="Public-Key", value='(5689; 1254; 687)', dtype='2-tuple')
+
+        # Test missing tuple length.
+        with self.assertRaises(ValueError):
+            _ = Property(name="Public-Key", value='(5689; 1254; 687)', dtype='-tuple')
+
+        # Test invalid tuple format.
+        with self.assertRaises(ValueError):
+            _ = Property(name="Public-Key", value='5689; 1254; 687', dtype='3-tuple')
+
     def test_get_set_value(self):
         values = [1, 2, 3, 4, 5]
         p = Property("property", value=values)

--- a/test/test_samplefile.py
+++ b/test/test_samplefile.py
@@ -197,7 +197,7 @@ class AttributeTest(unittest.TestCase):
     def test_conversion_int_to_float(self):
         p = odml.Property("test", "1", dtype="int")
         self.assertEqual(p.dtype, "int")
-        self.assertEqual(type(p.value[0]), int)
+        self.assertIsInstance(p.value[0], int)
         p.dtype = "float"  # change dtype
         self.assertEqual(p.dtype, "float")
         self.assertEqual(p.value[0], 1.0)


### PR DESCRIPTION
This pull request 
- Changes the way dtypes handles default values. If a value is `None` or `""`, the defined default value of the corresponding dtype is returned. Closes #228.
- This update also fixes load errors on Empty and None boolean and datetime related values. Closes #245.
- Use only `date/time_get`: Removing all `x_set` functions for time, date and datetime and using the corresponding `x_get` functions instead analogous to all other dtype functions. This also fixes, that the `date_set` was redirected to `time_set`.
- Introduces and uses constants for the format of date, time and datetime in dtypes. This also has the benefit of exposing the required formats to the outside.

It also
- Replaces all `type()` checks with `isinstance()`. Closes #226.
- Fixes saving of odML style tuples in `xmlparser` and `dict_parser`.
- Fixes saving datetime related values to JSON. Closes #248.
- Adds and updates dtype related tests.
- Makes odml.Document use the dtypes date setter on init. Closes #249.
