### PR TITLE
dtype handling and setting id

### DIFF
--- a/odml/doc.py
+++ b/odml/doc.py
@@ -48,6 +48,18 @@ class BaseDocument(base.sectionable, Document):
         """
         return self._id
 
+    def new_id(self, id=None):
+        """
+        new_id sets the id of the current object to a RFC 4122 compliant UUID.
+        If an id was provided, it is assigned if it is RFC 4122 UUID format compliant.
+        If no id was provided, a new UUID is generated and assigned.
+        :param id: UUID string as specified in RFC 4122.
+        """
+        if id is not None:
+            self._id = str(uuid.UUID(id))
+        else:
+            self._id = str(uuid.uuid4())
+
     @property
     def author(self):
         """

--- a/odml/dtypes.py
+++ b/odml/dtypes.py
@@ -76,14 +76,19 @@ def infer_dtype(value):
 
 def valid_type(dtype):
     """
-    Checks if *dtype* is a valid type
+    Checks if *dtype* is a valid odML value data type.
     """
+    if dtype is None:
+        return True
+
+    if not isinstance(dtype, str):
+        return False
+
     dtype = dtype.lower()
     if dtype in _dtype_map:
         dtype = _dtype_map[dtype]
+
     if hasattr(DType, dtype):
-        return True
-    if dtype is None:
         return True
 
     return False

--- a/odml/dtypes.py
+++ b/odml/dtypes.py
@@ -84,7 +84,7 @@ def valid_type(dtype):
     if dtype is None:
         return True
 
-    if not isinstance(dtype, str):
+    if not isinstance(dtype, str) and not isinstance(dtype, unicode):
         return False
 
     dtype = dtype.lower()

--- a/odml/dtypes.py
+++ b/odml/dtypes.py
@@ -1,6 +1,9 @@
-import sys
 import datetime as dt
+import re
+import sys
+
 from enum import Enum
+
 self = sys.modules[__name__].__dict__
 
 """
@@ -89,6 +92,11 @@ def valid_type(dtype):
         dtype = _dtype_map[dtype]
 
     if hasattr(DType, dtype):
+        return True
+
+    # Check odML tuple dtype.
+    rexp = re.compile("^[0-9]*[1-9]-tuple$")
+    if len(rexp.findall(dtype)) == 1:
         return True
 
     return False

--- a/odml/property.py
+++ b/odml/property.py
@@ -58,8 +58,6 @@ class BaseProperty(base.baseobject, Property):
             print(e)
             self._id = str(uuid.uuid4())
         self._name = name
-        self._parent = None
-        self._value = []
         self._value_origin = value_origin
         self._unit = unit
         self._uncertainty = uncertainty
@@ -67,8 +65,17 @@ class BaseProperty(base.baseobject, Property):
         self._definition = definition
         self._dependency = dependency
         self._dependency_value = dependency_value
-        self._dtype = dtype
+
+        self._dtype = None
+        if dtypes.valid_type(dtype):
+            self._dtype = dtype
+        else:
+            print("Warning: Unknown dtype '%s'." % dtype)
+
+        self._value = []
         self.value = value
+
+        self._parent = None
         self.parent = parent
 
     @property

--- a/odml/property.py
+++ b/odml/property.py
@@ -75,6 +75,18 @@ class BaseProperty(base.baseobject, Property):
     def id(self):
         return self._id
 
+    def new_id(self, id=None):
+        """
+        new_id sets the id of the current object to a RFC 4122 compliant UUID.
+        If an id was provided, it is assigned if it is RFC 4122 UUID format compliant.
+        If no id was provided, a new UUID is generated and assigned.
+        :param id: UUID string as specified in RFC 4122.
+        """
+        if id is not None:
+            self._id = str(uuid.UUID(id))
+        else:
+            self._id = str(uuid.uuid4())
+
     @property
     def name(self):
         return self._name

--- a/odml/section.py
+++ b/odml/section.py
@@ -61,6 +61,18 @@ class BaseSection(base.sectionable, Section):
     def id(self):
         return self._id
 
+    def new_id(self, id=None):
+        """
+        new_id sets the id of the current object to a RFC 4122 compliant UUID.
+        If an id was provided, it is assigned if it is RFC 4122 UUID format compliant.
+        If no id was provided, a new UUID is generated and assigned.
+        :param id: UUID string as specified in RFC 4122.
+        """
+        if id is not None:
+            self._id = str(uuid.UUID(id))
+        else:
+            self._id = str(uuid.uuid4())
+
     @property
     def name(self):
         return self._name

--- a/test/test_doc.py
+++ b/test/test_doc.py
@@ -20,3 +20,21 @@ class TestSection(unittest.TestCase):
         # Make sure id cannot be reset programmatically.
         with self.assertRaises(AttributeError):
             doc.id = "someId"
+
+    def test_new_id(self):
+        doc = Document()
+        old_id = doc.id
+
+        # Test assign new generated id.
+        doc.new_id()
+        self.assertNotEqual(old_id, doc.id)
+
+        # Test assign new custom id.
+        old_id = doc.id
+        doc.new_id("79b613eb-a256-46bf-84f6-207df465b8f7")
+        self.assertNotEqual(old_id, doc.id)
+        self.assertEqual("79b613eb-a256-46bf-84f6-207df465b8f7", doc.id)
+
+        # Test invalid custom id exception.
+        with self.assertRaises(ValueError):
+            doc.new_id("crash and burn")

--- a/test/test_doc.py
+++ b/test/test_doc.py
@@ -7,9 +7,16 @@ class TestSection(unittest.TestCase):
     def setUp(self):
         pass
 
-    def test_set_id(self):
-        d = Document("D", id="79b613eb-a256-46bf-84f6-207df465b8f7")
-        self.assertEqual(d.id, "79b613eb-a256-46bf-84f6-207df465b8f7")
+    def test_id(self):
+        doc = Document()
+        self.assertIsNotNone(doc.id)
 
-        Document("D", id="id")
-        self.assertNotEqual(d.id, "id")
+        doc = Document("D", id="79b613eb-a256-46bf-84f6-207df465b8f7")
+        self.assertEqual(doc.id, "79b613eb-a256-46bf-84f6-207df465b8f7")
+
+        doc = Document("D", id="id")
+        self.assertNotEqual(doc.id, "id")
+
+        # Make sure id cannot be reset programmatically.
+        with self.assertRaises(AttributeError):
+            doc.id = "someId"

--- a/test/test_dtypes.py
+++ b/test/test_dtypes.py
@@ -9,6 +9,28 @@ class TestTypes(unittest.TestCase):
     def setUp(self):
         pass
 
+    def test_valid_type(self):
+        # Test None
+        self.assertTrue(typ.valid_type(None))
+
+        # Test that all DTypes classify as valid dtypes.
+        for curr_type in typ.DType:
+            self.assertTrue(typ.valid_type(curr_type), "Invalid DType %s" % curr_type)
+
+        # Test that provided shorthand dtypes return as valid dtypes.
+        for curr_shorthand in typ._dtype_map.keys():
+            self.assertTrue(typ.valid_type(curr_shorthand),
+                            "Invalid dtype shorthand %s" % curr_shorthand)
+
+        # Test valid tuple dtype
+        self.assertTrue(typ.valid_type("2-tuple"))
+        self.assertTrue(typ.valid_type("293939-tuple"))
+
+        # Test invalid dtypes
+        self.assertFalse(typ.valid_type(1))
+        self.assertFalse(typ.valid_type("unsupported"))
+        self.assertFalse(typ.valid_type("x-tuple"))
+
     def test_date(self):
         self.assertIsInstance(typ.date_get(None), datetime.date)
         self.assertIsInstance(typ.date_get(""), datetime.date)

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -207,7 +207,7 @@ class TestProperty(unittest.TestCase):
         p.value_origin = ""
         self.assertEqual(p.value_origin, None)
 
-    def test_set_id(self):
+    def test_id(self):
         p = Property(name="P")
         self.assertIsNotNone(p.id)
 
@@ -220,6 +220,24 @@ class TestProperty(unittest.TestCase):
         # Make sure id cannot be reset programmatically.
         with self.assertRaises(AttributeError):
             p.id = "someId"
+
+    def test_new_id(self):
+        prop = Property(name="prop")
+        old_id = prop.id
+
+        # Test assign new generated id.
+        prop.new_id()
+        self.assertNotEqual(old_id, prop.id)
+
+        # Test assign new custom id.
+        old_id = prop.id
+        prop.new_id("79b613eb-a256-46bf-84f6-207df465b8f7")
+        self.assertNotEqual(old_id, prop.id)
+        self.assertEqual("79b613eb-a256-46bf-84f6-207df465b8f7", prop.id)
+
+        # Test invalid custom id exception.
+        with self.assertRaises(ValueError):
+            prop.new_id("crash and burn")
 
     def test_merge(self):
         p_dst = Property("p1", value=[1, 2, 3], unit="Hz", definition="Freude\t schoener\nGoetterfunken\n",

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -70,7 +70,7 @@ class TestProperty(unittest.TestCase):
         p5.extend("[a, b, c]")
         self.assertEqual(len(p5), 5)
 
-        p6 = Property("test", {"name": "Marie", "name":"Johanna"})
+        p6 = Property("test", {"name": "Marie", "name": "Johanna"})
         self.assertEqual(len(p6), 1)
 
         # Test tuple dtype value.
@@ -82,14 +82,6 @@ class TestProperty(unittest.TestCase):
         # Test invalid tuple length
         with self.assertRaises(ValueError):
             _ = Property(name="Public-Key", value='(5689; 1254; 687)', dtype='2-tuple')
-
-        # Test missing tuple length.
-        with self.assertRaises(ValueError):
-            _ = Property(name="Public-Key", value='(5689; 1254; 687)', dtype='-tuple')
-
-        # Test invalid tuple format.
-        with self.assertRaises(ValueError):
-            _ = Property(name="Public-Key", value='5689; 1254; 687', dtype='3-tuple')
 
     def test_get_set_value(self):
         values = [1, 2, 3, 4, 5]

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -185,7 +185,34 @@ class TestProperty(unittest.TestCase):
             Property("property_doc", parent=Document())
 
     def test_dtype(self):
-        pass
+        prop = Property(name="prop")
+
+        # Test assignment of all supported dtypes.
+        for curr_type in DType:
+            prop.dtype = curr_type
+            self.assertEqual(prop.dtype, curr_type)
+
+        # Test assignment of dtype alias.
+        prop.dtype = "bool"
+        self.assertEqual(prop.dtype, "bool")
+        prop.dtype = "str"
+        self.assertEqual(prop.dtype, "str")
+
+        # Test assignment of tuple.
+        prop.dtype = "2-tuple"
+        self.assertEqual(prop.dtype, "2-tuple")
+
+        # Test set None
+        prop.dtype = None
+        self.assertIsNone(prop.dtype)
+
+        # Test assignment fails.
+        with self.assertRaises(AttributeError):
+            prop.dtype = 1
+        with self.assertRaises(AttributeError):
+            prop.dtype = "crash and burn"
+        with self.assertRaises(AttributeError):
+            prop.dtype = "x-tuple"
 
     def test_get_path(self):
         doc = Document()

--- a/test/test_section.py
+++ b/test/test_section.py
@@ -56,7 +56,7 @@ class TestSection(unittest.TestCase):
     def test_path(self):
         pass
 
-    def test_set_id(self):
+    def test_id(self):
         s = Section(name="S")
         self.assertIsNotNone(s.id)
 
@@ -69,6 +69,24 @@ class TestSection(unittest.TestCase):
         # Make sure id cannot be reset programmatically.
         with self.assertRaises(AttributeError):
             s.id = "someId"
+
+    def test_new_id(self):
+        sec = Section(name="sec")
+        old_id = sec.id
+
+        # Test assign new generated id.
+        sec.new_id()
+        self.assertNotEqual(old_id, sec.id)
+
+        # Test assign new custom id.
+        old_id = sec.id
+        sec.new_id("79b613eb-a256-46bf-84f6-207df465b8f7")
+        self.assertNotEqual(old_id, sec.id)
+        self.assertEqual("79b613eb-a256-46bf-84f6-207df465b8f7", sec.id)
+
+        # Test invalid custom id exception.
+        with self.assertRaises(ValueError):
+            sec.new_id("crash and burn")
 
     def test_clone(self):
         # Check parent removal in clone.


### PR DESCRIPTION
This PR
- Introduces the `new_id()` method to Document, Section and Property and adds the corresponding tests. Closes #262.
- Setting a dtype now also supports odML style tuple types and adds tests Closes #254.
- When initializing a Property now only valid dtypes will be set. Adds corresponding tests. Closes #253.


