### PR TITLE
Refactor Property and Section merge

### DIFF
--- a/odml/base.py
+++ b/odml/base.py
@@ -113,7 +113,7 @@ class SmartList(SafeList):
         Only values of the instance *content_type* can be added to the SmartList.
         """
         self._content_type = content_type
-        super(SafeList, self).__init__()
+        super(SmartList, self).__init__()
 
     def __getitem__(self, key):
         """

--- a/odml/base.py
+++ b/odml/base.py
@@ -108,6 +108,13 @@ class SafeList(list):
 
 class SmartList(SafeList):
 
+    def __init__(self, content_type):
+        """
+        Only values of the instance *content_type* can be added to the SmartList.
+        """
+        self._content_type = content_type
+        super(SafeList, self).__init__()
+
     def __getitem__(self, key):
         """
         Provides element index also by searching for an element with a given
@@ -147,9 +154,9 @@ class SmartList(SafeList):
 
 @allow_inherit_docstring
 class sectionable(baseobject):
-
     def __init__(self):
-        self._sections = SmartList()
+        from odml.section import Section
+        self._sections = SmartList(Section)
         self._repository = None
 
     @property
@@ -518,9 +525,10 @@ class sectionable(baseobject):
         Clone this object recursively allowing to copy it independently
         to another document
         """
+        from odml.section import Section
         obj = super(sectionable, self).clone(children)
         obj._parent = None
-        obj._sections = SmartList()
+        obj._sections = SmartList(Section)
         if children:
             for s in self._sections:
                 obj.append(s.clone())

--- a/odml/base.py
+++ b/odml/base.py
@@ -138,16 +138,14 @@ class SmartList(SafeList):
                 return True
 
     def append(self, *obj_tuple):
-        from odml.section import BaseSection
-        from odml.doc import BaseDocument
         for obj in obj_tuple:
             if obj.name in self:
                 raise KeyError(
                     "Object with the same name already exists! " + str(obj))
 
-            if (not isinstance(obj, BaseSection)) & \
-               isinstance(self, BaseDocument):
-                raise KeyError("Object " + str(obj) + " is not a Section.")
+            if not isinstance(obj, self._content_type):
+                raise ValueError("List only supports elements of type '%s'" %
+                                 self._content_type)
 
             super(SmartList, self).append(obj)
 

--- a/odml/base.py
+++ b/odml/base.py
@@ -84,29 +84,7 @@ class baseobject(_baseobj):
         return id(self)
 
 
-class SafeList(list):
-
-    def index(self, obj):
-        """
-        Find obj in list
-
-        Be sure to use "is" based comparison (instead of __eq__)
-        """
-        for i, e in enumerate(self):
-            if e is obj:
-                return i
-        raise ValueError("remove: %s not in list" % repr(obj))
-
-    def remove(self, obj):
-        """
-        Remove an element from this list.
-
-        Be sure to use "is" based comparison (instead of __eq__)
-        """
-        del self[self.index(obj)]
-
-
-class SmartList(SafeList):
+class SmartList(list):
 
     def __init__(self, content_type):
         """
@@ -160,6 +138,25 @@ class SmartList(SafeList):
         for obj in self:
             if (hasattr(obj, "name") and obj.name == key) or key == obj:
                 return True
+
+    def index(self, obj):
+        """
+        Find obj in list
+
+        Be sure to use "is" based comparison (instead of __eq__)
+        """
+        for i, e in enumerate(self):
+            if e is obj:
+                return i
+        raise ValueError("remove: %s not in list" % repr(obj))
+
+    def remove(self, obj):
+        """
+        Remove an element from this list.
+
+        Be sure to use "is" based comparison (instead of __eq__)
+        """
+        del self[self.index(obj)]
 
     def append(self, *obj_tuple):
         for obj in obj_tuple:

--- a/odml/base.py
+++ b/odml/base.py
@@ -132,6 +132,30 @@ class SmartList(SafeList):
         # and fail eventually
         raise KeyError(key)
 
+    def __setitem__(self, key, value):
+        """
+        Replaces item at list[*key*] with *value*.
+        :param key: index position
+        :param value: object that replaces item at *key* position.
+                      value has to be of the same content type as the list.
+                      In this context usually a Section or a Property.
+        """
+        if not isinstance(value, self._content_type):
+            raise ValueError("List only supports elements of type '%s'" %
+                             self._content_type)
+
+        # If required remove new object from its old parents child-list
+        if hasattr(value, "_parent") and (value._parent and value in value._parent):
+            value._parent.remove(value)
+
+        # If required move parent reference from replaced to new object
+        # and set parent reference on replaced object None.
+        if hasattr(self[key], "_parent"):
+            value._parent = self[key]._parent
+            self[key]._parent = None
+
+        super(SmartList, self).__setitem__(key, value)
+
     def __contains__(self, key):
         for obj in self:
             if (hasattr(obj, "name") and obj.name == key) or key == obj:

--- a/odml/base.py
+++ b/odml/base.py
@@ -95,8 +95,7 @@ class SmartList(list):
 
     def __getitem__(self, key):
         """
-        Provides element index also by searching for an element with a given
-        name
+        Provides element index also by searching for an element with a given name.
         """
         # Try normal list index first (for integers)
         if isinstance(key, int):
@@ -142,8 +141,6 @@ class SmartList(list):
     def index(self, obj):
         """
         Find obj in list
-
-        Be sure to use "is" based comparison (instead of __eq__)
         """
         for i, e in enumerate(self):
             if e is obj:
@@ -153,8 +150,6 @@ class SmartList(list):
     def remove(self, obj):
         """
         Remove an element from this list.
-
-        Be sure to use "is" based comparison (instead of __eq__)
         """
         del self[self.index(obj)]
 

--- a/odml/property.py
+++ b/odml/property.py
@@ -373,7 +373,7 @@ class BaseProperty(base.baseobject, Property):
 
         return obj
 
-    def merge_check(self, source, strict):
+    def merge_check(self, source, strict=True):
         """
         Checks whether a source Property can be merged with self as destination and
         raises a ValueError if any of the attributes definition, uncertainty, reference

--- a/odml/property.py
+++ b/odml/property.py
@@ -398,7 +398,8 @@ class BaseProperty(base.baseobject, Property):
             if self_def != other_def:
                 raise ValueError("odml.Property.merge: src and dest definitions do not match!")
 
-        if self.uncertainty is not None and other.uncertainty is not None:
+        if (self.uncertainty is not None and other.uncertainty is not None and
+                self.uncertainty != other.uncertainty):
             raise ValueError("odml.Property.merge: src and dest uncertainty both set and do not match!")
 
         if self.reference is not None and other.reference is not None:

--- a/odml/property.py
+++ b/odml/property.py
@@ -438,7 +438,9 @@ class BaseProperty(base.baseobject, Property):
                even when information may be lost. Default is True, i.e. no conversion,
                and a ValueError will be raised if types do not match.
         """
-        assert(isinstance(other, BaseProperty))
+        if not isinstance(other, BaseProperty):
+            raise TypeError("odml.Property.merge: odml Property required.")
+
         self.merge_check(other, strict)
 
         if self.value_origin is None and other.value_origin is not None:

--- a/odml/property.py
+++ b/odml/property.py
@@ -373,6 +373,49 @@ class BaseProperty(base.baseobject, Property):
 
         return obj
 
+    def merge_check(self, source, strict):
+        """
+        Checks whether a source Property can be merged with self as destination and
+        raises a ValueError if any of the attributes definition, uncertainty, reference
+        or value_origin and potentially dtype differ in source and destination.
+
+        :param source: an odML Property.
+        :param strict: If strict is True the dtypes of self and other must be identical.
+        """
+        if strict and self.dtype != source.dtype:
+            raise ValueError("odml.Property.merge: src and dest dtypes do not match!")
+
+        if self.unit is not None and source.unit is not None and self.unit != source.unit:
+            raise ValueError("odml.Property.merge: "
+                             "src and dest units (%s, %s) do not match!" %
+                             (source.unit, self.unit))
+
+        if self.definition is not None and source.definition is not None:
+            self_def = ''.join(map(str.strip, self.definition.split())).lower()
+            other_def = ''.join(map(str.strip, source.definition.split())).lower()
+            if self_def != other_def:
+                raise ValueError("odml.Property.merge: "
+                                 "src and dest definitions do not match!")
+
+        if (self.uncertainty is not None and source.uncertainty is not None and
+                self.uncertainty != source.uncertainty):
+            raise ValueError("odml.Property.merge: "
+                             "src and dest uncertainty both set and do not match!")
+
+        if self.reference is not None and source.reference is not None:
+            self_ref = ''.join(map(str.strip, self.reference.lower().split()))
+            other_ref = ''.join(map(str.strip, source.reference.lower().split()))
+            if self_ref != other_ref:
+                raise ValueError("odml.Property.merge: "
+                                 "src and dest references are in conflict!")
+
+        if self.value_origin is not None and source.value_origin is not None:
+            self_ori = ''.join(map(str.strip, self.value_origin.lower().split()))
+            other_ori = ''.join(map(str.strip, source.value_origin.lower().split()))
+            if self_ori != other_ori:
+                raise ValueError("odml.Property.merge: "
+                                 "src and dest value_origin are in conflict!")
+
     def merge(self, other, strict=True):
         """
         Merges the property 'other' into self, if possible. Information
@@ -386,33 +429,7 @@ class BaseProperty(base.baseobject, Property):
                and a ValueError will be raised if types do not match.
         """
         assert(isinstance(other, BaseProperty))
-        if strict and self.dtype != other.dtype:
-            raise ValueError("odml.Property.merge: src and dest dtypes do not match!")
-
-        if self.unit is not None and other.unit is not None and self.unit != other.unit:
-            raise ValueError("odml.Property.merge: src and dest units (%s, %s) do not match!" % (other.unit, self.unit))
-
-        if self.definition is not None and other.definition is not None:
-            self_def = ''.join(map(str.strip, self.definition.split())).lower()
-            other_def = ''.join(map(str.strip, other.definition.split())).lower()
-            if self_def != other_def:
-                raise ValueError("odml.Property.merge: src and dest definitions do not match!")
-
-        if (self.uncertainty is not None and other.uncertainty is not None and
-                self.uncertainty != other.uncertainty):
-            raise ValueError("odml.Property.merge: src and dest uncertainty both set and do not match!")
-
-        if self.reference is not None and other.reference is not None:
-            self_ref = ''.join(map(str.strip, self.reference.lower().split()))
-            other_ref = ''.join(map(str.strip, other.reference.lower().split()))
-            if self_ref != other_ref:
-                raise ValueError("odml.Property.merge: src and dest references are in conflict!")
-
-        if self.value_origin is not None and other.value_origin is not None:
-            self_ori = ''.join(map(str.strip, self.value_origin.lower().split()))
-            other_ori = ''.join(map(str.strip, other.value_origin.lower().split()))
-            if self_ori != other_ori:
-                raise ValueError("odml.Property.merge: src and dest value_origin are in conflict!")
+        self.merge_check(other, strict)
 
         if self.value_origin is None and other.value_origin is not None:
             self.value_origin = other.value_origin

--- a/odml/property.py
+++ b/odml/property.py
@@ -435,15 +435,16 @@ class BaseProperty(base.baseobject, Property):
 
     def merge(self, other, strict=True):
         """
-        Merges the property 'other' into self, if possible. Information
-        will be synchronized. Method will raise a ValueError when the
-        information in this property and the passed property are in
-        conflict.
+        Merges the Property 'other' into self, if possible. Information
+        will be synchronized. By default the method will raise a ValueError when the
+        information in this property and the passed property are in conflict.
 
         :param other: an odML Property.
         :param strict: Bool value to indicate whether types should be implicitly converted
                even when information may be lost. Default is True, i.e. no conversion,
-               and a ValueError will be raised if types do not match.
+               and a ValueError will be raised if types or other attributes do not match.
+               If a conflict arises with strict=False, the attribute value of self will
+               be kept, while the attribute value of other will be lost.
         """
         if not isinstance(other, BaseProperty):
             raise TypeError("odml.Property.merge: odml Property required.")

--- a/odml/property.py
+++ b/odml/property.py
@@ -382,8 +382,18 @@ class BaseProperty(base.baseobject, Property):
         :param source: an odML Property.
         :param strict: If strict is True the dtypes of self and other must be identical.
         """
+        if not isinstance(source, BaseProperty):
+            raise ValueError("odml.Property.merge: odML Property required.")
+
         if strict and self.dtype != source.dtype:
             raise ValueError("odml.Property.merge: src and dest dtypes do not match!")
+        else:
+            # Catch unmerge-able values also at this point to avoid
+            # failing Section tree merges which cannot easily be rolled back.
+            new_value = self._convert_value_input(source.value)
+            if not self._validate_values(new_value):
+                raise ValueError("odml.Property.merge: passed value(s) cannot "
+                                 "be converted to data type '%s'!" % self._dtype)
 
         if self.unit is not None and source.unit is not None and self.unit != source.unit:
             raise ValueError("odml.Property.merge: "

--- a/odml/section.py
+++ b/odml/section.py
@@ -456,6 +456,16 @@ class BaseSection(base.sectionable, Section):
                 self.include = self._include
             return
 
+        # Check all the way down the tree if the destination source and
+        # its children can be merged with self and its children since
+        # there is no rollback in case of a downstream merge error.
+        self.merge_check(section, strict)
+
+        if self.definition is None and section.definition is not None:
+            self.definition = section.definition
+        if self.reference is None and section.reference is not None:
+            self.reference = section.reference
+
         for obj in section:
             mine = self.contains(obj)
             if mine is not None:

--- a/odml/section.py
+++ b/odml/section.py
@@ -403,6 +403,37 @@ class BaseSection(base.sectionable, Section):
             raise ValueError("odml.Section.contains:"
                              "Section or Property object expected.")
 
+    def merge_check(self, source_section, strict):
+        """
+        Recursively checks whether a source Section and all its children can be merged
+        with self and all its children as destination and raises a ValueError if any of
+        the Section attributes definition and reference differ in source and destination.
+
+        :param source_section: an odML Section.
+        :param strict: If strict is True, the dtypes of same named Properties on the same
+                       tree level in source and destination have to be identical to pass
+                       the check.
+        """
+        if self.definition is not None and source_section.definition is not None:
+            self_def = ''.join(map(str.strip, self.definition.split())).lower()
+            other_def = ''.join(map(str.strip, source_section.definition.split())).lower()
+            if self_def != other_def:
+                raise ValueError(
+                    "odml.Section.merge: src and dest definitions do not match!")
+
+        if self.reference is not None and source_section.reference is not None:
+            self_ref = ''.join(map(str.strip, self.reference.lower().split()))
+            other_ref = ''.join(map(str.strip, source_section.reference.lower().split()))
+            if self_ref != other_ref:
+                raise ValueError(
+                    "odml.Section.merge: src and dest references are in conflict!")
+
+        # Check all the way down the rabbit hole / Section tree.
+        for obj in source_section:
+            mine = self.contains(obj)
+            if mine is not None:
+                mine.merge_check(obj, strict)
+
     def merge(self, section=None, strict=True):
         """
         Merges this section with another *section*.

--- a/odml/section.py
+++ b/odml/section.py
@@ -35,7 +35,7 @@ class BaseSection(base.sectionable, Section):
 
         # Sets _sections Smartlist and _repository to None, so run first.
         super(BaseSection, self).__init__()
-        self._props = base.SmartList()
+        self._props = base.SmartList(Property)
 
         try:
             if id is not None:
@@ -373,7 +373,7 @@ class BaseSection(base.sectionable, Section):
         obj = super(BaseSection, self).clone(children)
         obj._id = str(uuid.uuid4())
 
-        obj._props = base.SmartList()
+        obj._props = base.SmartList(Property)
         if children:
             for p in self._props:
                 obj.append(p.clone())

--- a/odml/section.py
+++ b/odml/section.py
@@ -410,18 +410,18 @@ class BaseSection(base.sectionable, Section):
         the Section attributes definition and reference differ in source and destination.
 
         :param source_section: an odML Section.
-        :param strict: If strict is True, the dtypes of same named Properties on the same
-                       tree level in source and destination have to be identical to pass
-                       the check.
+        :param strict: If True, definition and reference attributes of any merged Sections
+                       as well as most attributes of merged Properties on the same
+                       tree level in source and destination have to be identical.
         """
-        if self.definition is not None and source_section.definition is not None:
+        if strict and self.definition is not None and source_section.definition is not None:
             self_def = ''.join(map(str.strip, self.definition.split())).lower()
             other_def = ''.join(map(str.strip, source_section.definition.split())).lower()
             if self_def != other_def:
                 raise ValueError(
                     "odml.Section.merge: src and dest definitions do not match!")
 
-        if self.reference is not None and source_section.reference is not None:
+        if strict and self.reference is not None and source_section.reference is not None:
             self_ref = ''.join(map(str.strip, self.reference.lower().split()))
             other_ref = ''.join(map(str.strip, source_section.reference.lower().split()))
             if self_ref != other_ref:

--- a/odml/section.py
+++ b/odml/section.py
@@ -7,7 +7,7 @@ from . import format
 from . import terminology
 from .doc import BaseDocument
 # this is supposedly ok, as we only use it for an isinstance check
-from .property import Property
+from .property import BaseProperty
 # it MUST however not be used to create any Property objects
 from .tools.doc_inherit import inherit_docstring, allow_inherit_docstring
 
@@ -35,7 +35,7 @@ class BaseSection(base.sectionable, Section):
 
         # Sets _sections Smartlist and _repository to None, so run first.
         super(BaseSection, self).__init__()
-        self._props = base.SmartList(Property)
+        self._props = base.SmartList(BaseProperty)
 
         try:
             if id is not None:
@@ -269,7 +269,7 @@ class BaseSection(base.sectionable, Section):
         if isinstance(obj, Section):
             self._sections.append(obj)
             obj._parent = self
-        elif isinstance(obj, Property):
+        elif isinstance(obj, BaseProperty):
             self._props.append(obj)
             obj._parent = self
         elif isinstance(obj, collections.Iterable) and not isinstance(obj, str):
@@ -291,7 +291,7 @@ class BaseSection(base.sectionable, Section):
 
         # Make sure only Sections and Properties with unique names will be added.
         for obj in obj_list:
-            if not isinstance(obj, Section) and not isinstance(obj, Property):
+            if not isinstance(obj, Section) and not isinstance(obj, BaseProperty):
                 raise ValueError("odml.Section.extend: "
                                  "Can only extend sections and properties.")
 
@@ -299,7 +299,7 @@ class BaseSection(base.sectionable, Section):
                 raise KeyError("odml.Section.extend: "
                                "Section with name '%s' already exists." % obj.name)
 
-            elif isinstance(obj, Property) and obj.name in self.properties:
+            elif isinstance(obj, BaseProperty) and obj.name in self.properties:
                 raise KeyError("odml.Section.extend: "
                                "Property with name '%s' already exists." % obj.name)
 
@@ -322,7 +322,7 @@ class BaseSection(base.sectionable, Section):
 
             self._sections.insert(position, obj)
             obj._parent = self
-        elif isinstance(obj, Property):
+        elif isinstance(obj, BaseProperty):
             if obj.name in self.properties:
                 raise ValueError("odml.Section.insert: "
                                  "Property with name '%s' already exists." % obj.name)
@@ -344,7 +344,7 @@ class BaseSection(base.sectionable, Section):
         if isinstance(obj, Section):
             self._sections.remove(obj)
             obj._parent = None
-        elif isinstance(obj, Property):
+        elif isinstance(obj, BaseProperty):
             self._props.remove(obj)
             obj._parent = None
         else:
@@ -373,7 +373,7 @@ class BaseSection(base.sectionable, Section):
         obj = super(BaseSection, self).clone(children)
         obj._id = str(uuid.uuid4())
 
-        obj._props = base.SmartList(Property)
+        obj._props = base.SmartList(BaseProperty)
         if children:
             for p in self._props:
                 obj.append(p.clone())
@@ -391,7 +391,7 @@ class BaseSection(base.sectionable, Section):
         if isinstance(obj, Section):
             return super(BaseSection, self).contains(obj)
 
-        elif isinstance(obj, Property):
+        elif isinstance(obj, BaseProperty):
             for i in self._props:
                 if obj.name == i.name:
                     return i

--- a/odml/section.py
+++ b/odml/section.py
@@ -266,7 +266,7 @@ class BaseSection(base.sectionable, Section):
 
         :param obj: Section or Property object.
         """
-        if isinstance(obj, Section):
+        if isinstance(obj, BaseSection):
             self._sections.append(obj)
             obj._parent = self
         elif isinstance(obj, BaseProperty):
@@ -291,11 +291,11 @@ class BaseSection(base.sectionable, Section):
 
         # Make sure only Sections and Properties with unique names will be added.
         for obj in obj_list:
-            if not isinstance(obj, Section) and not isinstance(obj, BaseProperty):
+            if not isinstance(obj, BaseSection) and not isinstance(obj, BaseProperty):
                 raise ValueError("odml.Section.extend: "
                                  "Can only extend sections and properties.")
 
-            elif isinstance(obj, Section) and obj.name in self.sections:
+            elif isinstance(obj, BaseSection) and obj.name in self.sections:
                 raise KeyError("odml.Section.extend: "
                                "Section with name '%s' already exists." % obj.name)
 
@@ -315,7 +315,7 @@ class BaseSection(base.sectionable, Section):
         :param position: index at which the object should be inserted.
         :param obj: Section or Property object.
         """
-        if isinstance(obj, Section):
+        if isinstance(obj, BaseSection):
             if obj.name in self.sections:
                 raise ValueError("odml.Section.insert: "
                                  "Section with name '%s' already exists." % obj.name)
@@ -341,7 +341,7 @@ class BaseSection(base.sectionable, Section):
 
         :param obj: Section or Property object.
         """
-        if isinstance(obj, Section):
+        if isinstance(obj, BaseSection):
             self._sections.remove(obj)
             obj._parent = None
         elif isinstance(obj, BaseProperty):
@@ -388,7 +388,7 @@ class BaseSection(base.sectionable, Section):
 
         :param obj: Section or Property object.
         """
-        if isinstance(obj, Section):
+        if isinstance(obj, BaseSection):
             return super(BaseSection, self).contains(obj)
 
         elif isinstance(obj, BaseProperty):

--- a/odml/section.py
+++ b/odml/section.py
@@ -173,8 +173,10 @@ class BaseSection(base.sectionable, Section):
             return None
 
     @definition.setter
-    def definition(self, val):
-        self._definition = val
+    def definition(self, new_value):
+        if new_value == "":
+            new_value = None
+        self._definition = new_value
 
     @definition.deleter
     def definition(self):
@@ -186,6 +188,8 @@ class BaseSection(base.sectionable, Section):
 
     @reference.setter
     def reference(self, new_value):
+        if new_value == "":
+            new_value = None
         self._reference = new_value
 
     # API (public)

--- a/odml/section.py
+++ b/odml/section.py
@@ -403,7 +403,7 @@ class BaseSection(base.sectionable, Section):
             raise ValueError("odml.Section.contains:"
                              "Section or Property object expected.")
 
-    def merge_check(self, source_section, strict):
+    def merge_check(self, source_section, strict=True):
         """
         Recursively checks whether a source Section and all its children can be merged
         with self and all its children as destination and raises a ValueError if any of

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -430,6 +430,73 @@ class TestProperty(unittest.TestCase):
         with self.assertRaises(ValueError):
             prop.new_id("crash and burn")
 
+    def test_merge_check(self):
+        # Test dtype check
+        source = Property(name="source", dtype="string")
+        destination = Property(name="destination", dtype="string")
+
+        destination.merge_check(source, True)
+        source.dtype = "int"
+        with self.assertRaises(ValueError):
+            destination.merge_check(source, True)
+        destination.merge_check(source, False)
+
+        # Test unit check
+        source = Property(name="source", unit="Hz")
+        destination = Property(name="destination", unit="Hz")
+
+        destination.merge_check(source, True)
+        source.unit = "s"
+        with self.assertRaises(ValueError):
+            destination.merge_check(source, True)
+        with self.assertRaises(ValueError):
+            destination.merge_check(source, False)
+
+        # Test uncertainty check
+        source = Property(name="source", uncertainty=0.0)
+        destination = Property(name="destination", uncertainty=0.0)
+
+        destination.merge_check(source, True)
+        source.uncertainty = 10.0
+        with self.assertRaises(ValueError):
+            destination.merge_check(source, True)
+        with self.assertRaises(ValueError):
+            destination.merge_check(source, False)
+
+        # Test definition check
+        source = Property(name="source", definition="Freude\t schoener\nGoetterfunken\n")
+        destination = Property(name="destination",
+                               definition="FREUDE schoener GOETTERfunken")
+
+        destination.merge_check(source, True)
+        source.definition = "Freunde schoender Goetterfunken"
+        with self.assertRaises(ValueError):
+            destination.merge_check(source, True)
+        with self.assertRaises(ValueError):
+            destination.merge_check(source, False)
+
+        # Test reference check
+        source = Property(name="source", reference="portal.g-node.org")
+        destination = Property(name="destination", reference="portal.g-node.org")
+
+        destination.merge_check(source, True)
+        source.reference = "portal.g-node.org/odml/terminologies/v1.1"
+        with self.assertRaises(ValueError):
+            destination.merge_check(source, True)
+        with self.assertRaises(ValueError):
+            destination.merge_check(source, False)
+
+        # Test value origin check
+        source = Property(name="source", value_origin="file")
+        destination = Property(name="destination", value_origin="file")
+
+        destination.merge_check(source, True)
+        source.value_origin = "other file"
+        with self.assertRaises(ValueError):
+            destination.merge_check(source, True)
+        with self.assertRaises(ValueError):
+            destination.merge_check(source, False)
+
     def test_merge(self):
         p_dst = Property("p1", value=[1, 2, 3], unit="Hz", definition="Freude\t schoener\nGoetterfunken\n",
                          reference="portal.g-node.org", uncertainty=0.0, value_origin="file")

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -441,6 +441,24 @@ class TestProperty(unittest.TestCase):
             destination.merge_check(source, True)
         destination.merge_check(source, False)
 
+        # Test value check
+        source = Property(name="source", value=[1, 2, 3])
+        destination = Property(name="destination", value=[4, 5, 6])
+        destination.merge_check(source, True)
+
+        # Test value convertable
+        source = Property(name="source", value=["7", "8"])
+        with self.assertRaises(ValueError):
+            destination.merge_check(source, True)
+        destination.merge_check(source, False)
+
+        # Test value not convertable
+        source = Property(name="source", value=["nine", "ten"])
+        with self.assertRaises(ValueError):
+            destination.merge_check(source, True)
+        with self.assertRaises(ValueError):
+            destination.merge_check(source, False)
+
         # Test unit check
         source = Property(name="source", unit="Hz")
         destination = Property(name="destination", unit="Hz")

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -432,7 +432,7 @@ class TestProperty(unittest.TestCase):
 
     def test_merge(self):
         p_dst = Property("p1", value=[1, 2, 3], unit="Hz", definition="Freude\t schoener\nGoetterfunken\n",
-                         reference="portal.g-node.org", uncertainty=0.0)
+                         reference="portal.g-node.org", uncertainty=0.0, value_origin="file")
         p_src = Property("p2", value=[2, 4, 6], unit="Hz", definition="FREUDE schoener GOETTERfunken")
 
         test_p = p_dst.clone()
@@ -451,11 +451,15 @@ class TestProperty(unittest.TestCase):
         p_inv_ref = p_src.clone()
         p_inv_ref.reference = "test"
 
+        p_inv_origin = p_src.clone()
+        p_inv_origin.value_origin = "other file"
+
         test_p = p_dst.clone()
         self.assertRaises(ValueError, test_p.merge, p_inv_unit)
         self.assertRaises(ValueError, test_p.merge, p_inv_def)
         self.assertRaises(ValueError, test_p.merge, p_inv_uncert)
         self.assertRaises(ValueError, test_p.merge, p_inv_ref)
+        self.assertRaises(ValueError, test_p.merge, p_inv_origin)
 
         test_p.reference = None
         test_p.merge(p_src)
@@ -472,6 +476,10 @@ class TestProperty(unittest.TestCase):
         test_p.definition = ""
         test_p.merge(p_src)
         self.assertEqual(test_p.definition, p_src.definition)
+
+        test_p.value_origin = ""
+        test_p.merge(p_src)
+        self.assertEqual(test_p.value_origin, p_src.value_origin)
 
         double_p = Property("adouble", value=3.14)
         int_p = Property("aint", value=3)

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -435,27 +435,29 @@ class TestProperty(unittest.TestCase):
         source = Property(name="source", dtype="string")
         destination = Property(name="destination", dtype="string")
 
-        destination.merge_check(source, True)
+        destination.merge_check(source)
         source.dtype = "int"
         with self.assertRaises(ValueError):
-            destination.merge_check(source, True)
+            destination.merge_check(source)
+
         destination.merge_check(source, False)
 
         # Test value check
         source = Property(name="source", value=[1, 2, 3])
         destination = Property(name="destination", value=[4, 5, 6])
-        destination.merge_check(source, True)
+        destination.merge_check(source)
 
         # Test value convertable
         source = Property(name="source", value=["7", "8"])
         with self.assertRaises(ValueError):
-            destination.merge_check(source, True)
+            destination.merge_check(source)
+
         destination.merge_check(source, False)
 
         # Test value not convertable
         source = Property(name="source", value=["nine", "ten"])
         with self.assertRaises(ValueError):
-            destination.merge_check(source, True)
+            destination.merge_check(source)
         with self.assertRaises(ValueError):
             destination.merge_check(source, False)
 
@@ -463,57 +465,57 @@ class TestProperty(unittest.TestCase):
         source = Property(name="source", unit="Hz")
         destination = Property(name="destination", unit="Hz")
 
-        destination.merge_check(source, True)
+        destination.merge_check(source)
         source.unit = "s"
         with self.assertRaises(ValueError):
-            destination.merge_check(source, True)
-        with self.assertRaises(ValueError):
-            destination.merge_check(source, False)
+            destination.merge_check(source)
+
+        destination.merge_check(source, False)
 
         # Test uncertainty check
         source = Property(name="source", uncertainty=0.0)
         destination = Property(name="destination", uncertainty=0.0)
 
-        destination.merge_check(source, True)
+        destination.merge_check(source)
         source.uncertainty = 10.0
         with self.assertRaises(ValueError):
-            destination.merge_check(source, True)
-        with self.assertRaises(ValueError):
-            destination.merge_check(source, False)
+            destination.merge_check(source)
+
+        destination.merge_check(source, False)
 
         # Test definition check
         source = Property(name="source", definition="Freude\t schoener\nGoetterfunken\n")
         destination = Property(name="destination",
                                definition="FREUDE schoener GOETTERfunken")
 
-        destination.merge_check(source, True)
+        destination.merge_check(source)
         source.definition = "Freunde schoender Goetterfunken"
         with self.assertRaises(ValueError):
-            destination.merge_check(source, True)
-        with self.assertRaises(ValueError):
-            destination.merge_check(source, False)
+            destination.merge_check(source)
+
+        destination.merge_check(source, False)
 
         # Test reference check
         source = Property(name="source", reference="portal.g-node.org")
         destination = Property(name="destination", reference="portal.g-node.org")
 
-        destination.merge_check(source, True)
+        destination.merge_check(source)
         source.reference = "portal.g-node.org/odml/terminologies/v1.1"
         with self.assertRaises(ValueError):
-            destination.merge_check(source, True)
-        with self.assertRaises(ValueError):
-            destination.merge_check(source, False)
+            destination.merge_check(source)
+
+        destination.merge_check(source, False)
 
         # Test value origin check
         source = Property(name="source", value_origin="file")
         destination = Property(name="destination", value_origin="file")
 
-        destination.merge_check(source, True)
+        destination.merge_check(source)
         source.value_origin = "other file"
         with self.assertRaises(ValueError):
-            destination.merge_check(source, True)
-        with self.assertRaises(ValueError):
-            destination.merge_check(source, False)
+            destination.merge_check(source)
+
+        destination.merge_check(source, False)
 
     def test_merge(self):
         p_dst = Property("p1", value=[1, 2, 3], unit="Hz", definition="Freude\t schoener\nGoetterfunken\n",

--- a/test/test_section.py
+++ b/test/test_section.py
@@ -87,6 +87,49 @@ class TestSection(unittest.TestCase):
         subsec.parent = None
         self.assertEqual(subsec.get_path(), "/")
 
+    def test_children(self):
+        sec = Section(name="sec")
+
+        # Test set sections
+        subsec = Section(name="subsec", parent=sec)
+        newsec = Section(name="newsec")
+
+        self.assertEqual(subsec.parent, sec)
+        self.assertEqual(sec.sections[0], subsec)
+        self.assertEqual(len(sec.sections), 1)
+        self.assertIsNone(newsec.parent)
+
+        sec.sections[0] = newsec
+        self.assertEqual(newsec.parent, sec)
+        self.assertEqual(sec.sections[0], newsec)
+        self.assertEqual(len(sec.sections), 1)
+        self.assertIsNone(subsec.parent)
+
+        # Test parent cleanup
+        root = Section(name="root")
+        sec.parent = root
+        subsec.parent = newsec
+
+        self.assertEqual(len(newsec.sections), 1)
+        self.assertEqual(newsec.sections[0], subsec)
+        self.assertEqual(subsec.parent, newsec)
+        self.assertEqual(len(root.sections), 1)
+        self.assertEqual(root.sections[0], sec)
+
+        subsec.parent = root
+        self.assertEqual(len(newsec.sections), 0)
+        self.assertEqual(subsec.parent, root)
+        self.assertEqual(len(root.sections), 2)
+        self.assertEqual(root.sections[1], subsec)
+
+        # Test set section fails
+        with self.assertRaises(ValueError):
+            sec.sections[0] = Document()
+        with self.assertRaises(ValueError):
+            sec.sections[0] = Property("fail")
+        with self.assertRaises(ValueError):
+            sec.sections[0] = "subsec"
+
     def test_id(self):
         s = Section(name="S")
         self.assertIsNotNone(s.id)

--- a/test/test_section.py
+++ b/test/test_section.py
@@ -33,6 +33,12 @@ class TestSection(unittest.TestCase):
         sec.reference = "%s_edit" % sec_ref
         self.assertEqual(sec.reference, "%s_edit" % sec_ref)
 
+        # Test setting attributes to None when '' is passed.
+        sec.reference = ""
+        self.assertIsNone(sec.reference)
+        sec.definition = ""
+        self.assertIsNone(sec.definition)
+
     def test_parent(self):
         s = Section("Section")
         self.assertIsNone(s.parent)

--- a/test/test_section.py
+++ b/test/test_section.py
@@ -130,6 +130,29 @@ class TestSection(unittest.TestCase):
         with self.assertRaises(ValueError):
             sec.sections[0] = "subsec"
 
+        # Test set properties
+        prop = Property(name="prop", parent=sec)
+        newprop = Property(name="newprop")
+
+        self.assertEqual(prop.parent, sec)
+        self.assertEqual(sec.properties[0], prop)
+        self.assertEqual(len(sec.properties), 1)
+        self.assertIsNone(newprop.parent)
+
+        sec.properties[0] = newprop
+        self.assertEqual(newprop.parent, sec)
+        self.assertEqual(sec.properties[0], newprop)
+        self.assertEqual(len(sec.properties), 1)
+        self.assertIsNone(prop.parent)
+
+        # Test set property fails
+        with self.assertRaises(ValueError):
+            sec.properties[0] = Document()
+        with self.assertRaises(ValueError):
+            sec.properties[0] = newsec
+        with self.assertRaises(ValueError):
+            sec.properties[0] = "prop"
+
     def test_id(self):
         s = Section(name="S")
         self.assertIsNotNone(s.id)


### PR DESCRIPTION
This PR
- Refactors `SmartList` to always only contain `Sections` or `Properties` and adds `setitem` with a check to make sure only the supported object type can be added to an existing list. Closes #272.
- Moves `Property.merge()` attribute checks to its own method `Property.merge_check()`, since its also required during `Section.merge()` when merging child Properties of a Section.
- Adds a `Section.merge_check()` method which validates whether a Section including all its subsections and subproperties can properly be merged. A `ValueError` is raised if any potential merge problem arises. This is necessary since a recursive Section merge cannot be easily rolled back once begun.
- A Section merge imports `reference` and `definition` from the source Section, if they were `None` in the destination. Closes #273.
- Refactors how merge `strict` is handled. Now all `Section` and `Property` attribute checks will only be done, if `strict=True`. On `strict=False` a `Section` or `Property` attribute will only be replaced with the source value, if the destination value is `None`. Otherwise the destination value will be kept and the source value lost.
- Adds tests for all changed and added methods.