### PR TITLE
Flatten odml class hierarchy

### DIFF
--- a/odml/base.py
+++ b/odml/base.py
@@ -160,7 +160,7 @@ class SmartList(list):
 
 
 @allow_inherit_docstring
-class sectionable(BaseObject):
+class Sectionable(BaseObject):
     def __init__(self):
         from odml.section import BaseSection
         self._sections = SmartList(BaseSection)
@@ -558,7 +558,7 @@ class sectionable(BaseObject):
         to another document
         """
         from odml.section import BaseSection
-        obj = super(sectionable, self).clone(children)
+        obj = super(Sectionable, self).clone(children)
         obj._parent = None
         obj._sections = SmartList(BaseSection)
         if children:

--- a/odml/base.py
+++ b/odml/base.py
@@ -9,11 +9,7 @@ from . import terminology
 from .tools.doc_inherit import allow_inherit_docstring
 
 
-class _baseobj(object):
-    pass
-
-
-class baseobject(_baseobj):
+class baseobject(object):
     _format = None
 
     def format(self):
@@ -40,9 +36,6 @@ class baseobject(_baseobj):
         unique within a document.
         """
         # cannot compare totally different stuff
-        if not isinstance(obj, _baseobj):
-            return False
-
         if not isinstance(self, obj.__class__):
             return False
 

--- a/odml/base.py
+++ b/odml/base.py
@@ -12,22 +12,11 @@ from .tools.doc_inherit import allow_inherit_docstring
 class BaseObject(object):
     _format = None
 
-    def format(self):
-        return self._format
-
-    @property
-    def document(self):
-        """ Returns the Document object in which this object is contained """
-        if self.parent is None:
-            return None
-        return self.parent.document
-
-    def get_terminology_equivalent(self):
+    def __hash__(self):
         """
-        Returns the equivalent object in an terminology (should there be one
-        defined) or None
+        Allow all odML objects to be hash-able.
         """
-        return None
+        return id(self)
 
     def __eq__(self, obj):
         """
@@ -53,6 +42,23 @@ class BaseObject(object):
         """
         return not self == obj
 
+    def format(self):
+        return self._format
+
+    @property
+    def document(self):
+        """ Returns the Document object in which this object is contained """
+        if self.parent is None:
+            return None
+        return self.parent.document
+
+    def get_terminology_equivalent(self):
+        """
+        Returns the equivalent object in an terminology (should there be one
+        defined) or None
+        """
+        return None
+
     def clean(self):
         """
         Stub that doesn't do anything for this class
@@ -69,12 +75,6 @@ class BaseObject(object):
         import copy
         obj = copy.copy(self)
         return obj
-
-    def __hash__(self):
-        """
-        Allow all odML objects to be hash-able.
-        """
-        return id(self)
 
 
 class SmartList(list):
@@ -166,6 +166,15 @@ class Sectionable(BaseObject):
         self._sections = SmartList(BaseSection)
         self._repository = None
 
+    def __getitem__(self, key):
+        return self._sections[key]
+
+    def __len__(self):
+        return len(self._sections)
+
+    def __iter__(self):
+        return self._sections.__iter__()
+
     @property
     def document(self):
         """
@@ -241,15 +250,6 @@ class Sectionable(BaseObject):
         """ Removes the specified child-section """
         self._sections.remove(section)
         section._parent = None
-
-    def __getitem__(self, key):
-        return self._sections[key]
-
-    def __len__(self):
-        return len(self._sections)
-
-    def __iter__(self):
-        return self._sections.__iter__()
 
     def itersections(self, recursive=True, yield_self=False,
                      filter_func=lambda x: True, max_depth=None):

--- a/odml/base.py
+++ b/odml/base.py
@@ -9,7 +9,7 @@ from . import terminology
 from .tools.doc_inherit import allow_inherit_docstring
 
 
-class baseobject(object):
+class BaseObject(object):
     _format = None
 
     def format(self):
@@ -160,7 +160,7 @@ class SmartList(list):
 
 
 @allow_inherit_docstring
-class sectionable(baseobject):
+class sectionable(BaseObject):
     def __init__(self):
         from odml.section import BaseSection
         self._sections = SmartList(BaseSection)

--- a/odml/doc.py
+++ b/odml/doc.py
@@ -8,12 +8,8 @@ from . import terminology
 from .tools.doc_inherit import inherit_docstring, allow_inherit_docstring
 
 
-class Document(base._baseobj):
-    pass
-
-
 @allow_inherit_docstring
-class BaseDocument(base.sectionable, Document):
+class BaseDocument(base.sectionable):
     """
     A representation of an odML document in memory.
     Its odml attributes are: *author*, *date*, *version* and *repository*.

--- a/odml/doc.py
+++ b/odml/doc.py
@@ -9,7 +9,7 @@ from .tools.doc_inherit import inherit_docstring, allow_inherit_docstring
 
 
 @allow_inherit_docstring
-class BaseDocument(base.sectionable):
+class BaseDocument(base.Sectionable):
     """
     A representation of an odML document in memory.
     Its odml attributes are: *author*, *date*, *version* and *repository*.

--- a/odml/doc.py
+++ b/odml/doc.py
@@ -37,6 +37,10 @@ class BaseDocument(base.Sectionable):
         self._date = None
         self.date = date
 
+    def __repr__(self):
+        return "<Doc %s by %s (%d sections)>" % (self._version, self._author,
+                                                 len(self._sections))
+
     @property
     def id(self):
         """
@@ -102,11 +106,6 @@ class BaseDocument(base.Sectionable):
     def parent(self):
         """ The parent of a document is always None. """
         return None
-
-    def __repr__(self):
-        return "<Doc %s by %s (%d sections)>" % (self._version,
-                                                 self._author,
-                                                 len(self._sections))
 
     def finalize(self):
         """

--- a/odml/property.py
+++ b/odml/property.py
@@ -79,6 +79,23 @@ class BaseProperty(base.BaseObject):
 
         self.parent = parent
 
+    def __len__(self):
+        return len(self._value)
+
+    def __getitem__(self, key):
+        return self._value[key]
+
+    def __setitem__(self, key, item):
+        if int(key) < 0 or int(key) > self.__len__():
+            raise IndexError("odml.Property.__setitem__: key %i invalid for "
+                             "array of length %i" % (int(key), self.__len__()))
+        try:
+            val = dtypes.get(item, self.dtype)
+            self._value[int(key)] = val
+        except Exception:
+            raise ValueError("odml.Property.__setitem__:  passed value cannot be "
+                             "converted to data type \'%s\'!" % self._dtype)
+
     @property
     def id(self):
         return self._id
@@ -489,22 +506,6 @@ class BaseProperty(base.BaseObject):
             return sec.properties[self.name]
         except KeyError:
             return None
-
-    def __len__(self):
-        return len(self._value)
-
-    def __getitem__(self, key):
-        return self._value[key]
-
-    def __setitem__(self, key, item):
-        if int(key) < 0 or int(key) > self.__len__():
-            raise IndexError("odml.Property.__setitem__: key %i invalid for array of length %i"
-                             % (int(key), self.__len__()))
-        try:
-            val = dtypes.get(item, self.dtype)
-            self._value[int(key)] = val
-        except Exception:
-            raise ValueError("odml.Property.__setitem__:  passed value cannot be converted to data type \'%s\'!" % self._dtype)
 
     def extend(self, obj, strict=True):
         """

--- a/odml/property.py
+++ b/odml/property.py
@@ -8,12 +8,8 @@ from . import format as frmt
 from .tools.doc_inherit import inherit_docstring, allow_inherit_docstring
 
 
-class Property(base._baseobj):
-    pass
-
-
 @allow_inherit_docstring
-class BaseProperty(base.baseobject, Property):
+class BaseProperty(base.baseobject):
     """An odML Property"""
     _format = frmt.Property
 

--- a/odml/property.py
+++ b/odml/property.py
@@ -9,7 +9,7 @@ from .tools.doc_inherit import inherit_docstring, allow_inherit_docstring
 
 
 @allow_inherit_docstring
-class BaseProperty(base.baseobject):
+class BaseProperty(base.BaseObject):
     """An odML Property"""
     _format = frmt.Property
 

--- a/odml/section.py
+++ b/odml/section.py
@@ -12,12 +12,8 @@ from .property import BaseProperty
 from .tools.doc_inherit import inherit_docstring, allow_inherit_docstring
 
 
-class Section(base._baseobj):
-    pass
-
-
 @allow_inherit_docstring
-class BaseSection(base.sectionable, Section):
+class BaseSection(base.sectionable):
     """ An odML Section """
     type = None
     # id = None

--- a/odml/section.py
+++ b/odml/section.py
@@ -13,7 +13,7 @@ from .tools.doc_inherit import inherit_docstring, allow_inherit_docstring
 
 
 @allow_inherit_docstring
-class BaseSection(base.sectionable):
+class BaseSection(base.Sectionable):
     """ An odML Section """
     type = None
     # id = None
@@ -239,9 +239,9 @@ class BaseSection(base.sectionable):
             return self.parent.get_repository()
         return super(BaseSection, self).repository
 
-    @base.sectionable.repository.setter
+    @base.Sectionable.repository.setter
     def repository(self, url):
-        base.sectionable.repository.fset(self, url)
+        base.Sectionable.repository.fset(self, url)
 
     @inherit_docstring
     def get_terminology_equivalent(self):

--- a/odml/section.py
+++ b/odml/section.py
@@ -55,8 +55,22 @@ class BaseSection(base.Sectionable):
         self.parent = parent
 
     def __repr__(self):
-        return "<Section %s[%s] (%d)>" % (self._name, self.type,
-                                          len(self._sections))
+        return "<Section %s[%s] (%d)>" % (self._name, self.type, len(self._sections))
+
+    def __iter__(self):
+        """
+        Iterate over each section and property contained in this section
+        """
+        for section in self._sections:
+            yield section
+        for prop in self._props:
+            yield prop
+
+    def __len__(self):
+        """
+        Number of children (sections AND properties)
+        """
+        return len(self._sections) + len(self._props)
 
     @property
     def id(self):
@@ -349,21 +363,6 @@ class BaseSection(base.Sectionable):
             obj._parent = None
         else:
             raise ValueError("Can only remove sections and properties")
-
-    def __iter__(self):
-        """
-        Iterate over each section and property contained in this section
-        """
-        for section in self._sections:
-            yield section
-        for prop in self._props:
-            yield prop
-
-    def __len__(self):
-        """
-        Number of children (sections AND properties)
-        """
-        return len(self._sections) + len(self._props)
 
     def clone(self, children=True):
         """

--- a/odml/tools/odmlparser.py
+++ b/odml/tools/odmlparser.py
@@ -102,18 +102,6 @@ class ODMLReader:
         self.parser = parser
         self.warnings = []
 
-    def is_valid_attribute(self, attr, fmt):
-        if attr in fmt.arguments_keys:
-            return attr
-
-        if fmt.revmap(attr):
-            return attr
-
-        msg = "Invalid element <%s> inside <%s> tag" % (attr, fmt.__class__.__name__)
-        print(msg)
-        self.warnings.append(msg)
-        return None
-
     def from_file(self, file, doc_format=None):
 
         if self.parser == 'XML':


### PR DESCRIPTION
This PR flattens the odml class hierarchy since it is unlikely that we will support differing odML class implementations any time soon.
- removing `base._baseobj` class, making `BaseObject` the root odML class.
- removing `doc.Document` class, making `BaseDocument` the only odML document class.
- removing `section.Section` class, making `BaseSection` the only odML section class.
- removing `property.Property` class making `BaseProperty` the only odML property class.

The PR also
- reorders various magic methods to the top of their respective class to easier spot where custom magic methods are defined.
- renames `baseobject` and `sectionable` to `BaseObject` and `Sectionable` respectively.
- removes outdated `odmlparser.is_valid_attribute` method which had already previously copied to the new dictparser class.
