### PR TITLE
Refactor required attribute handling

### DIFF
--- a/odml/format.py
+++ b/odml/format.py
@@ -130,7 +130,7 @@ class Section(Format):
     _args = {
         'id': 0,
         'type': 1,
-        'name': 0,
+        'name': 1,
         'definition': 0,
         'reference': 0,
         'link': 0,

--- a/odml/property.py
+++ b/odml/property.py
@@ -123,6 +123,14 @@ class BaseProperty(base.BaseObject):
 
     @name.setter
     def name(self, new_name):
+        if self.name == new_name:
+            return
+
+        curr_parent = self.parent
+        if hasattr(curr_parent, "properties") and new_name in curr_parent.properties:
+
+            raise KeyError("Object with the same name already exists!")
+
         self._name = new_name
 
     def __repr__(self):

--- a/odml/property.py
+++ b/odml/property.py
@@ -13,7 +13,7 @@ class BaseProperty(base.BaseObject):
     """An odML Property"""
     _format = frmt.Property
 
-    def __init__(self, name, value=None, parent=None, unit=None,
+    def __init__(self, name=None, value=None, parent=None, unit=None,
                  uncertainty=None, reference=None, definition=None,
                  dependency=None, dependency_value=None, dtype=None,
                  value_origin=None, id=None):
@@ -58,6 +58,11 @@ class BaseProperty(base.BaseObject):
             print(e)
             self._id = str(uuid.uuid4())
 
+        # Use id if no name was provided.
+        if not name:
+            name = self._id
+
+        self._name = name
         self._parent = None
         self._name = name
         self._value_origin = value_origin

--- a/odml/section.py
+++ b/odml/section.py
@@ -98,6 +98,13 @@ class BaseSection(base.Sectionable):
 
     @name.setter
     def name(self, new_value):
+        if self.name == new_value:
+            return
+
+        curr_parent = self.parent
+        if hasattr(curr_parent, "sections") and new_value in curr_parent.sections:
+            raise KeyError("Object with the same name already exists!")
+
         self._name = new_value
 
     @property

--- a/odml/section.py
+++ b/odml/section.py
@@ -25,7 +25,7 @@ class BaseSection(base.Sectionable):
 
     _format = format.Section
 
-    def __init__(self, name, type=None, parent=None,
+    def __init__(self, name=None, type=None, parent=None,
                  definition=None, reference=None,
                  repository=None, link=None, include=None, id=None):
 
@@ -41,6 +41,10 @@ class BaseSection(base.Sectionable):
         except ValueError as e:
             print(e)
             self._id = str(uuid.uuid4())
+
+        # Use id if no name was provided.
+        if not name:
+            name = self._id
 
         self._parent = None
         self._name = name

--- a/odml/tools/odmlparser.py
+++ b/odml/tools/odmlparser.py
@@ -48,6 +48,10 @@ class ODMLWriter:
             raise ParserException(msg)
 
         with open(filename, 'w') as file:
+            # Add XML header to support odML stylesheets.
+            if self.parser == 'XML':
+                file.write(xmlparser.XMLWriter.header)
+
             file.write(self.to_string(odml_document))
 
     def to_string(self, odml_document):

--- a/odml/tools/xmlparser.py
+++ b/odml/tools/xmlparser.py
@@ -288,19 +288,6 @@ class XMLReader(object):
         # Instantiate the current odML object with the parsed attributes.
         obj = fmt.create(**arguments)
 
-        for k, v in arguments.items():
-            if hasattr(obj, k) and (getattr(obj, k) is None or k == 'id'):
-                try:
-                    if k == 'id' and v is not None:
-                        obj._id = v
-                    else:
-                        setattr(obj, k, v)
-                except Exception as e:
-                    self.warn("cannot set '%s' property on <%s>: %s" %
-                              (k, root.tag, repr(e)), root)
-                    if not self.ignore_errors:
-                        raise e
-
         if insert_children:
             for child in children:
                 obj.append(child)

--- a/odml/tools/xmlparser.py
+++ b/odml/tools/xmlparser.py
@@ -231,10 +231,6 @@ class XMLReader(object):
         arguments = {}
         extra_args = {}
         children = []
-        text = []
-
-        if root.text:
-            text.append(root.text.strip())
 
         for k, v in root.attrib.iteritems():
             k = k.lower()
@@ -273,8 +269,6 @@ class XMLReader(object):
             else:
                 self.error("Invalid element <%s> in odML document section <%s>"
                            % (node.tag, root.tag), node)
-            if node.tail:
-                text.append(node.tail.strip())
 
         if sys.version_info > (3,):
             self.check_mandatory_arguments(dict(list(arguments.items()) +

--- a/odml/tools/xmlparser.py
+++ b/odml/tools/xmlparser.py
@@ -227,6 +227,12 @@ class XMLReader(object):
         """
         Parse an odml node based on the format description *fmt*
         and instantiate the corresponding object.
+        :param root: lxml.etree node containing an odML object or object tree.
+        :param fmt: odML class corresponding to the content of the root node.
+        :param insert_children: Bool value. When True, child elements of the root node
+                                will be parsed to their odML equivalents and appended to
+                                the odML document. When False, child elements of the
+                                root node will be ignored.
         """
         arguments = {}
         extra_args = {}

--- a/odml/tools/xmlparser.py
+++ b/odml/tools/xmlparser.py
@@ -223,10 +223,10 @@ class XMLReader(object):
             return None  # won't be able to parse this one
         return getattr(self, "parse_" + node.tag)(node, self.tags[node.tag])
 
-    def parse_tag(self, root, fmt, insert_children=True, create=None):
+    def parse_tag(self, root, fmt, insert_children=True):
         """
         Parse an odml node based on the format description *fmt*
-        and a function *create* to instantiate a corresponding object
+        and instantiate the corresponding object.
         """
         arguments = {}
         extra_args = {}
@@ -284,10 +284,9 @@ class XMLReader(object):
             self.check_mandatory_arguments(dict(arguments.items() +
                                            extra_args.items()),
                                            fmt, root.tag, root)
-        if create is None:
-            obj = fmt.create()
-        else:
-            obj = create(args=arguments, text=''.join(text), children=children)
+
+        # Instantiate the current odML object with the parsed attributes.
+        obj = fmt.create(**arguments)
 
         for k, v in arguments.items():
             if hasattr(obj, k) and (getattr(obj, k) is None or k == 'id'):
@@ -312,12 +311,10 @@ class XMLReader(object):
         return doc
 
     def parse_section(self, root, fmt):
-        return self.parse_tag(root, fmt,
-                              create=lambda args, **kargs: fmt.create(**args))
+        return self.parse_tag(root, fmt)
 
     def parse_property(self, root, fmt):
-        create = lambda children, args, **kargs: fmt.create(**args)
-        return self.parse_tag(root, fmt, insert_children=False, create=create)
+        return self.parse_tag(root, fmt, insert_children=False)
 
 
 if __name__ == '__main__':

--- a/odml/tools/xmlparser.py
+++ b/odml/tools/xmlparser.py
@@ -312,20 +312,8 @@ class XMLReader(object):
         return doc
 
     def parse_section(self, root, fmt):
-        name = root.get("name")  # property name= overrides
-        if name is None:  # the element
-            name_node = root.find("name")
-            if name_node is not None:
-                name = name_node.text
-                root.remove(name_node)
-                # delete the name_node so its value won't
-                # be used to overwrite the already set name-attribute
-
-        if name is None:
-            self.error("Missing name element in <section>", root)
-
         return self.parse_tag(root, fmt,
-                              create=lambda **kargs: fmt.create(name))
+                              create=lambda args, **kargs: fmt.create(**args))
 
     def parse_property(self, root, fmt):
         create = lambda children, args, **kargs: fmt.create(**args)

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -327,6 +327,17 @@ class TestProperty(unittest.TestCase):
         assert(p.dtype == 'string')
         assert(p.value == ['7', '20', '1 Dog', 'Seven'])
 
+    def test_name(self):
+        # Test id is used when name is not provided
+        p = Property()
+        self.assertIsNotNone(p.name)
+        self.assertEqual(p.name, p.id)
+
+        # Test name is properly set on init
+        name = "rumpelstilzchen"
+        p = Property(name)
+        self.assertEqual(p.name, name)
+
     def test_parent(self):
         p = Property("property_section", parent=Section("S"))
         self.assertIsInstance(p.parent, BaseSection)

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -338,6 +338,29 @@ class TestProperty(unittest.TestCase):
         p = Property(name)
         self.assertEqual(p.name, name)
 
+        # Test name can be properly set on single and connected Properties
+        prop = Property()
+        self.assertNotEqual(prop.name, "prop")
+        prop.name = "prop"
+        self.assertEqual(prop.name, "prop")
+
+        sec = Section()
+        prop_a = Property(parent=sec)
+        self.assertNotEqual(prop_a.name, "prop_a")
+        prop_a.name = "prop_a"
+        self.assertEqual(prop_a.name, "prop_a")
+
+        # Test property name can be changed with siblings
+        prop_b = Property(name="prop_b", parent=sec)
+        self.assertEqual(prop_b.name, "prop_b")
+        prop_b.name = "prop"
+        self.assertEqual(prop_b.name, "prop")
+
+        # Test property name set will fail on existing sibling with same name
+        with self.assertRaises(KeyError):
+            prop_b.name = "prop_a"
+        self.assertEqual(prop_b.name, "prop")
+
     def test_parent(self):
         p = Property("property_section", parent=Section("S"))
         self.assertIsInstance(p.parent, BaseSection)

--- a/test/test_section.py
+++ b/test/test_section.py
@@ -39,6 +39,21 @@ class TestSection(unittest.TestCase):
         sec.definition = ""
         self.assertIsNone(sec.definition)
 
+    def test_name(self):
+        # Test id is used when name is not provided
+        s = Section()
+        self.assertIsNotNone(s.name)
+        self.assertEqual(s.name, s.id)
+
+        # Test name is properly set on init
+        name = "rumpelstilzchen"
+        s = Section(name)
+        self.assertEqual(s.name, name)
+
+        name = "rumpelstilzchen"
+        s = Section(name=name)
+        self.assertEqual(s.name, name)
+
     def test_parent(self):
         s = Section("Section")
         self.assertIsNone(s.parent)

--- a/test/test_section.py
+++ b/test/test_section.py
@@ -54,6 +54,35 @@ class TestSection(unittest.TestCase):
         s = Section(name=name)
         self.assertEqual(s.name, name)
 
+        # Test name can be properly set on single and connected Sections
+        sec = Section()
+        self.assertNotEqual(sec.name, "sec")
+        sec.name = "sec"
+        self.assertEqual(sec.name, "sec")
+
+        subsec_a = Section(parent=sec)
+        self.assertNotEqual(subsec_a.name, "subsec_a")
+        subsec_a.name = "subsec_a"
+        self.assertEqual(subsec_a.name, "subsec_a")
+
+        # Test subsection name can be changed with siblings
+        subsec_b = Section(name="subsec_b", parent=sec)
+        self.assertEqual(subsec_b.name, "subsec_b")
+        subsec_b.name = "subsec"
+        self.assertEqual(subsec_b.name, "subsec")
+
+        # Test subsection name set will fail on existing sibling with same name
+        with self.assertRaises(KeyError):
+            subsec_b.name = "subsec_a"
+        self.assertEqual(subsec_b.name, "subsec")
+
+        # Test section name set will fail on existing same name document sibling
+        doc = Document()
+        sec_a = Section(name="a", parent=doc)
+        sec_b = Section(name="b", parent=doc)
+        with self.assertRaises(KeyError):
+            sec_b.name = "a"
+
     def test_parent(self):
         s = Section("Section")
         self.assertIsNone(s.parent)


### PR DESCRIPTION
This PR mainly refactors how required attributes of `Section` and `Property` are handled.
- Required attributes of odML entities in `format.py` where changed: `Section.name`, `Section.type` and `Property.name` are the only attributes set to be required for their respective odML entites. Closes #240.
- `Section` and `Property` `name` can now be `None` on initialization. If this is the case, the entities' `id` values is used as `name` value.
- Hardcoded checks for existing `name` attributes in the XML Parser are removed. Only attributes set as required in `format` are now used to check for missing required odML entity attributes. Close #241.
- The `name` attribute of a `Section` or a `Property` can now only be rewritten, if there is no sibling with the same name on the same hierarchical level. Closes #283.
- Various unused codebits where removed from the XML Parser.
