### PR TITLE
Add custom InvalidVersion exception

### DIFF
--- a/odml/tools/dict_parser.py
+++ b/odml/tools/dict_parser.py
@@ -5,7 +5,7 @@ into a proper and verified odML document.
 
 from .. import format as odmlfmt
 from ..info import FORMAT_VERSION
-from .parser_utils import ParserException
+from .parser_utils import InvalidVersionException, ParserException
 
 
 class DictWriter:
@@ -131,7 +131,7 @@ class DictReader:
             msg = ("Cannot read file: invalid odML document format version '%s'. \n"
                    "This package supports odML format versions: '%s'."
                    % (self.parsed_doc.get('odml-version'), FORMAT_VERSION))
-            raise ParserException(msg)
+            raise InvalidVersionException(msg)
 
         self.parsed_doc = self.parsed_doc['Document']
 

--- a/odml/tools/parser_utils.py
+++ b/odml/tools/parser_utils.py
@@ -11,3 +11,10 @@ class ParserException(Exception):
     Exception wrapper used by various odML parsers.
     """
     pass
+
+
+class InvalidVersionException(ParserException):
+    """
+    Exception wrapper to indicate a non-compatible odML version.
+    """
+    pass

--- a/odml/tools/xmlparser.py
+++ b/odml/tools/xmlparser.py
@@ -18,7 +18,7 @@ except ImportError:
 
 from .. import format
 from ..info import FORMAT_VERSION
-from .parser_utils import ParserException
+from .parser_utils import InvalidVersionException, ParserException
 
 try:
     unicode = unicode
@@ -162,7 +162,7 @@ class XMLReader(object):
             msg = ("Cannot read file: invalid odML document format version '%s'. \n"
                    "This package supports odML format versions: '%s'."
                    % (root.attrib['version'], FORMAT_VERSION))
-            raise ParserException(msg)
+            raise InvalidVersionException(msg)
 
     def from_file(self, xml_file):
         """


### PR DESCRIPTION
This PR adds a custom InvalidVersion exception and uses it in xml and dict parser when an old odML format version is read in. This is required to differentiate this case from other ParserExceptions e.g. when trying to load an odML file via odml-ui.