### PR TITLE
Harmonize attribute naming with nixpy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 dist
 build
 eggs
+.eggs
 parts
 
 # odml files

--- a/odml/base.py
+++ b/odml/base.py
@@ -615,3 +615,19 @@ class Sectionable(BaseObject):
         parent) or None
         """
         return self._repository
+
+    def create_section(self, name, type="undefined", oid=None):
+        """
+        Creates a new subsection that is a child of this section.
+
+        :param name: The name of the section to create.
+        :param type: The type of the section.
+        :param oid: object id, UUID string as specified in RFC 4122. If no id
+                    is provided, an id will be generated and assigned.
+        :return: The new section.
+        """
+        from odml.section import BaseSection
+        sec = BaseSection(name=name, type=type, oid=oid)
+        sec.parent = self
+
+        return sec

--- a/odml/property.py
+++ b/odml/property.py
@@ -62,7 +62,6 @@ class BaseProperty(base.BaseObject):
         if not name:
             name = self._id
 
-        self._name = name
         self._parent = None
         self._name = name
         self._value_origin = value_origin

--- a/odml/section.py
+++ b/odml/section.py
@@ -583,21 +583,6 @@ class BaseSection(base.Sectionable):
 
         return self._reorder(self.parent.sections, new_index)
 
-    def create_section(self, name, type="undefined", oid=None):
-        """
-        Creates a new subsection that is a child of this section.
-
-        :param name: The name of the section to create.
-        :param type: The type of the section.
-        :param oid: object id, UUID string as specified in RFC 4122. If no id
-                    is provided, an id will be generated and assigned.
-        :return: The new section.
-        """
-        sec = BaseSection(name=name, type=type, oid=oid)
-        sec.parent = self
-
-        return sec
-
     def create_property(self, name, value=None, dtype=None, oid=None):
         """
         Create a new property that is a child of this section.

--- a/odml/section.py
+++ b/odml/section.py
@@ -237,6 +237,12 @@ class BaseSection(base.Sectionable):
         return self._props
 
     @property
+    def props(self):
+        """ The list of all properties contained in this section;
+            NIXpy format style alias for 'properties'."""
+        return self._props
+
+    @property
     def sections(self):
         """ The list of all child-sections of this section """
         return self._sections

--- a/odml/section.py
+++ b/odml/section.py
@@ -582,3 +582,17 @@ class BaseSection(base.Sectionable):
                              "Section has no parent, cannot reorder in parent list.")
 
         return self._reorder(self.parent.sections, new_index)
+
+    def create_section(self, name, type="undefined", oid=None):
+        """
+        Creates a new subsection that is a child of this section.
+
+        :param name: The name of the section to create.
+        :param type: The type of the section.
+        :param oid: object id, UUID string as specified in RFC 4122. If no id
+                    is provided, an id will be generated and assigned.
+        :return: The new section.
+        """
+        sec = BaseSection(name=name, type=type, oid=oid)
+        sec.parent = self
+        return sec

--- a/odml/section.py
+++ b/odml/section.py
@@ -595,4 +595,24 @@ class BaseSection(base.Sectionable):
         """
         sec = BaseSection(name=name, type=type, oid=oid)
         sec.parent = self
+
         return sec
+
+    def create_property(self, name, value=None, dtype=None, oid=None):
+        """
+        Create a new property that is a child of this section.
+
+        :param name: The name of the property.
+        :param value: Some data value, it can be a single value or
+                      a list of homogeneous values.
+        :param dtype: The data type of the values stored in the property,
+                      if dtype is not given, the type is deduced from the values.
+                      Check odml.DType for supported data types.
+        :param oid: object id, UUID string as specified in RFC 4122. If no id
+                    is provided, an id will be generated and assigned.
+        :return: The new property.
+        """
+        prop = BaseProperty(name=name, value=value, dtype=dtype, oid=oid)
+        prop.parent = self
+
+        return prop

--- a/test/test_doc.py
+++ b/test/test_doc.py
@@ -291,3 +291,32 @@ class TestSection(unittest.TestCase):
 
         doc_b.sections["subsecA"].properties[0].name = "newPropB"
         self.assertNotEqual(doc_a, doc_b)
+
+    def test_create_section(self):
+        root = Document()
+        self.assertEqual(len(root.sections), 0)
+
+        name = "subsec"
+        type = "subtype"
+        oid = "79b613eb-a256-46bf-84f6-207df465b8f7"
+        subsec = root.create_section(name, type, oid)
+
+        self.assertEqual(len(root.sections), 1)
+        self.assertEqual(subsec.parent, root)
+        self.assertEqual(root.sections[name], subsec)
+        self.assertEqual(root.sections[name].type, type)
+        self.assertEqual(root.sections[name].oid, oid)
+
+        name = "othersec"
+        subsec = root.create_section(name)
+        self.assertEqual(len(root.sections), 2)
+        self.assertEqual(subsec.parent, root)
+        self.assertEqual(root.sections[name], subsec)
+        self.assertEqual(root.sections[name].type, "undefined")
+
+        name = "subsubsec"
+        subsec = root.sections[0].create_section(name)
+        self.assertEqual(len(root.sections), 2)
+        self.assertEqual(subsec.parent, root.sections[0])
+        self.assertEqual(len(root.sections[0].sections), 1)
+        self.assertEqual(root.sections[0].sections[0].name, name)

--- a/test/test_section.py
+++ b/test/test_section.py
@@ -203,6 +203,29 @@ class TestSection(unittest.TestCase):
         with self.assertRaises(ValueError):
             sec.properties[0] = "prop"
 
+        # same tests with props alias
+        prop = Property(name="prop2", parent=sec)
+        newprop = Property(name="newprop2")
+
+        self.assertEqual(prop.parent, sec)
+        self.assertEqual(sec.props[1], prop)
+        self.assertEqual(len(sec.props), 2)
+        self.assertIsNone(newprop.parent)
+
+        sec.props[1] = newprop
+        self.assertEqual(newprop.parent, sec)
+        self.assertEqual(sec.props[1], newprop)
+        self.assertEqual(len(sec.props), 2)
+        self.assertIsNone(prop.parent)
+
+        # Test set property fails
+        with self.assertRaises(ValueError):
+            sec.props[1] = Document()
+        with self.assertRaises(ValueError):
+            sec.props[1] = newsec
+        with self.assertRaises(ValueError):
+            sec.props[1] = "prop2"
+
     def test_id(self):
         s = Section(name="S")
         self.assertIsNotNone(s.id)

--- a/test/test_section.py
+++ b/test/test_section.py
@@ -863,6 +863,35 @@ class TestSection(unittest.TestCase):
         self.assertNotEqual(sec_a, sec_b)
         self.assertNotEqual(sec_a.properties, sec_b.properties)
 
+    def test_create_section(self):
+        root = Section("root")
+        self.assertEqual(len(root.sections), 0)
+
+        name = "subsec"
+        type = "subtype"
+        oid = "79b613eb-a256-46bf-84f6-207df465b8f7"
+        subsec = root.create_section(name, type, oid)
+
+        self.assertEqual(len(root.sections), 1)
+        self.assertEqual(subsec.parent, root)
+        self.assertEqual(root.sections[name], subsec)
+        self.assertEqual(root.sections[name].type, type)
+        self.assertEqual(root.sections[name].oid, oid)
+
+        name = "othersec"
+        subsec = root.create_section(name)
+        self.assertEqual(len(root.sections), 2)
+        self.assertEqual(subsec.parent, root)
+        self.assertEqual(root.sections[name], subsec)
+        self.assertEqual(root.sections[name].type, "undefined")
+
+        name = "subsubsec"
+        subsec = root.sections[0].create_section(name)
+        self.assertEqual(len(root.sections), 2)
+        self.assertEqual(subsec.parent, root.sections[0])
+        self.assertEqual(len(root.sections[0].sections), 1)
+        self.assertEqual(root.sections[0].sections[0].name, name)
+
     def test_link(self):
         pass
 

--- a/test/test_section.py
+++ b/test/test_section.py
@@ -892,6 +892,34 @@ class TestSection(unittest.TestCase):
         self.assertEqual(len(root.sections[0].sections), 1)
         self.assertEqual(root.sections[0].sections[0].name, name)
 
+    def test_create_property(self):
+        root = Section("root")
+        self.assertEqual(len(root.properties), 0)
+
+        name = "prop"
+        oid = "79b613eb-a256-46bf-84f6-207df465b8f7"
+        prop = root.create_property(name, oid=oid)
+        self.assertEqual(len(root.properties), 1)
+        self.assertEqual(prop.parent, root)
+        self.assertEqual(root.properties[name].oid, oid)
+
+        name = "test_values"
+        values = ["a", "b"]
+        prop = root.create_property(name, value=values)
+        self.assertEqual(len(root.properties), 2)
+        self.assertEqual(root.properties[name].value, values)
+
+        name = "test_dtype"
+        dtype = "str"
+        prop = root.create_property(name, dtype=dtype)
+        self.assertEqual(len(root.properties), 3)
+        self.assertEqual(root.properties[name].dtype, dtype)
+
+        name = "test_dtype_fail"
+        dtype = "I do not exist"
+        prop = root.create_property(name, dtype=dtype)
+        self.assertIsNone(prop.dtype)
+
     def test_link(self):
         pass
 


### PR DESCRIPTION
This PR aims to make working with odml and the odml part of nixpy more similar. 

The `create_section` method is added to `Document` and `Section` and the `create_property` method to `Section`. The `props` alias attribute of `properties` is added to `Section` to close #299.

Let me know if I missed any nixpy attribute that should be ported to odml as well and whether we should unify `__repr__` of `Section` and `Property` as well, since they are currently different.

See also #308 for completeness of this topic.