### PR TITLE
[Converter] Remove check for duplicate section names

### DIFF
--- a/odml/tools/version_converter.py
+++ b/odml/tools/version_converter.py
@@ -377,12 +377,9 @@ class VersionConverter(object):
         sec_map = {}
         prop_map = {}
         root = tree.getroot()
+
+        # update property names
         for sec in root.iter("section"):
-            n = sec.find("name")
-            if n is not None:
-                cls._change_entity_name(sec_map, n)
-            else:
-                raise Exception("Section attribute name is not specified")
             for prop in sec.iter("property"):
                 if prop.getparent() == sec:
                     n = prop.find("name")


### PR DESCRIPTION
Fixes #289 by removing checks for duplicate section names. I could not find an old odML version, in which it was possible to generate sibling sections having the same name, so this check might not be too important. Please tell me if this is wrong, so I can find another solution for #289.