### PR TITLE
Toggle warning messages on load

### DIFF
--- a/odml/fileio.py
+++ b/odml/fileio.py
@@ -2,13 +2,14 @@ import os
 from .tools.odmlparser import ODMLReader, ODMLWriter
 
 
-def load(filename, backend="xml"):
+def load(filename, backend="xml", show_warnings=True):
     """
     Load an odML document from file.
     :param filename: Path and filename from where the odML document
                      is to be loaded and parsed.
     :param backend: File format of the file containing the odML document.
                     The default format is XML.
+    :param show_warnings: Toggle whether to print warnings to the command line.
     :return: The parsed odML document.
     """
     if not os.path.exists(filename):
@@ -16,7 +17,7 @@ def load(filename, backend="xml"):
               (filename if len(filename) < 20 else "...%s" % filename[19:])
         raise FileNotFoundError(msg)
 
-    reader = ODMLReader(backend)
+    reader = ODMLReader(backend, show_warnings)
     return reader.from_file(filename)
 
 

--- a/odml/tools/dict_parser.py
+++ b/odml/tools/dict_parser.py
@@ -104,8 +104,14 @@ class DictReader:
     A reader to parse dictionaries with odML content into a proper odML document.
     """
 
-    def __init__(self):
+    def __init__(self, show_warnings=True):
+        """
+        :param show_warnings: Toggle whether to print warnings to the command line.
+                              Any warnings can be accessed via the Reader's class
+                              warnings attribute after parsing is done.
+        """
         self.parsed_doc = None  # Python dictionary object equivalent
+        self.show_warnings = show_warnings
         self.warnings = []
 
     def is_valid_attribute(self, attr, fmt):
@@ -116,8 +122,9 @@ class DictReader:
             return attr
 
         msg = "Invalid element <%s> inside <%s> tag" % (attr, fmt.__class__.__name__)
-        print(msg)
         self.warnings.append(msg)
+        if self.show_warnings:
+            print(msg)
         return None
 
     def to_odml(self, parsed_doc):

--- a/odml/tools/odmlparser.py
+++ b/odml/tools/odmlparser.py
@@ -107,19 +107,25 @@ class ODMLReader:
         json_odml_doc = ODMLReader(parser='JSON').from_file("odml_doc.json")
     """
 
-    def __init__(self, parser='XML'):
+    def __init__(self, parser='XML', show_warnings=True):
+        """
+        :param parser: odml parser; supported are 'XML', 'JSON', 'YAML' and 'RDF'.
+        :param show_warnings: Toggle whether to print warnings to the command line.
+        """
         self.doc = None  # odML document
         self.parsed_doc = None  # Python dictionary object equivalent
         parser = parser.upper()
         if parser not in SUPPORTED_PARSERS:
             raise NotImplementedError("'%s' odML parser does not exist!" % parser)
         self.parser = parser
+        self.show_warnings = show_warnings
         self.warnings = []
 
     def from_file(self, file, doc_format=None):
 
         if self.parser == 'XML':
-            par = xmlparser.XMLReader(ignore_errors=True)
+            par = xmlparser.XMLReader(ignore_errors=True,
+                                      show_warnings=self.show_warnings)
             self.warnings = par.warnings
             self.doc = par.from_file(file)
             return self.doc
@@ -132,7 +138,8 @@ class ODMLReader:
                     print(err)
                     return
 
-            self.doc = DictReader().to_odml(self.parsed_doc)
+            par = DictReader(show_warnings=self.show_warnings)
+            self.doc = par.to_odml(self.parsed_doc)
             # Provide original file name via the in memory document
             self.doc._origin_file_name = basename(file)
             return self.doc
@@ -145,7 +152,8 @@ class ODMLReader:
                     print("JSON Decoder Error: %s" % err)
                     return
 
-            self.doc = DictReader().to_odml(self.parsed_doc)
+            par = DictReader(show_warnings=self.show_warnings)
+            self.doc = par.to_odml(self.parsed_doc)
             # Provide original file name via the in memory document
             self.doc._origin_file_name = basename(file)
             return self.doc

--- a/odml/tools/xmlparser.py
+++ b/odml/tools/xmlparser.py
@@ -148,10 +148,21 @@ class XMLReader(object):
         >>> doc = XMLReader().from_file("file.odml")
     """
 
-    def __init__(self, ignore_errors=False, filename=None):
+    def __init__(self, ignore_errors=False, show_warnings=True, filename=None):
+        """
+        :param ignore_errors: To allow loading and fixing of invalid odml files
+                              encountered errors can be converted to warnings
+                              instead. Such a document can only be saved when
+                              all errors have been addressed though.
+        :param show_warnings: Toggle whether to print warnings to the command line.
+                              Any warnings can be accessed via the Reader's class
+                              warnings attribute after parsing is done.
+        :param filename: Path to an odml file.
+        """
         self.parser = ET.XMLParser(remove_comments=True)
         self.tags = dict([(obj.name, obj) for obj in format.__all__])
         self.ignore_errors = ignore_errors
+        self.show_warnings = show_warnings
         self.filename = filename
         self.warnings = []
 
@@ -229,8 +240,10 @@ class XMLReader(object):
                 self.filename, elem.sourceline, elem.tag, msg)
         else:
             msg = "warning: %s\n" % msg
+
         self.warnings.append(msg)
-        sys.stderr.write(msg)
+        if self.show_warnings:
+            sys.stderr.write(msg)
 
     def parse_element(self, node):
         if node.tag not in self.tags:


### PR DESCRIPTION
This small PR resolves #305 by adding a 'show_warnings' flag to all load methods. The flag is 'True' by default and toggles whether warning messages are printed to the command line when loading an odML document.