### PR TITLE
pyyaml dependency upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ matrix:
       python: "2.7"
       env: COVERALLS=1
     - os: linux
-      python: "3.4"
-    - os: linux
       python: "3.5"
     - os: linux
       python: "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ install:
       export PIPCMD=pip;
     fi;
 
-  - $PIPCMD install lxml enum34 pyyaml rdflib
+  - $PIPCMD install lxml enum34 pyyaml==4.2b4 rdflib
 
 script:
   - which $PYCMD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Governance model
 
 The project has a core team of **maintainers** who are long-term contributors and responsible for coordinating the project. There is also a set of one-time or short period **contributors**. We consider everyone a contributor who reports issues, opens pull requests, or takes part in issue discussions. Any such contribution is welcome. Maintainers have commit access to the repository and will review and merge pull requests. Becoming a maintainer is possible for everyone who wants to help maintaining and shaping the project and to take over more responsibility. Requests to become a maintainer need to be approved by the existing maintainers.
 
-Any addition to the code happens via pull requests (there are only very few exceptions in which someone pushes directly to master, see below for more information). Thus, any contribution will be reviewed before it is merged. Bug fixes and other contributions to the API will undergo this pragmatic approach. Format or API changes, especially those that would lead to breaking changes, will be discussed via the issue tracker and video meetings and need to be agreed on by the maintainters. We aim at consensus decisions, but where this is not possible decisions are made by majority vote among the maintainers.
+Any addition to the code happens via pull requests (there are only very few exceptions in which someone pushes directly to master, see below for more information). Thus, any contribution will be reviewed before it is merged. Bug fixes and other contributions to the API will undergo this pragmatic approach. Format or API changes, especially those that would lead to breaking changes, will be discussed via the issue tracker and video meetings and need to be agreed on by the maintainers. We aim at consensus decisions, but where this is not possible decisions are made by majority vote among the maintainers.
 
 
 Contributing
@@ -67,12 +67,12 @@ Each pull request that passes all builds and tests should be reviewed by at leas
 If a contribution is rather complex or leads to significant API changes, the respective pull request should be
 reviewed by two other developers.
 In such cases the first reviewer or the contributor should request a second review in a comment.
-
+To streamline the review process reviewers are encouraged to use the github "review" option.
 
 Testing
 -------
 
-* Unit test can be found in the test sub directory. Currently, the test coverage is a bit low but we are working on improving it.
+* Unit tests can be found in the test sub directory. Currently, the test coverage is a bit low but we are working on improving it.
 
 * Provide a unit test for every class, method or function.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Travis build](https://travis-ci.org/G-Node/python-odml.svg?branch=master)
-![Appveyor](https://ci.appveyor.com/api/projects/status/2wfvsu7boe18kwjy?svg=true)
+[![Build status](https://ci.appveyor.com/api/projects/status/br7pe6atlwdg5618/branch/master?svg=true)](https://ci.appveyor.com/project/G-Node/python-odml/branch/master)
 ![Test coverage](https://coveralls.io/repos/github/G-Node/python-odml/badge.svg?branch=master)
 
 # odML (Open metaData Markup Language) core library

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ packages = [
 with open('README.md') as f:
     description_text = f.read()
 
-install_req = ["lxml", "pyyaml==3.13", "rdflib", "docopt", "pathlib"]
+install_req = ["lxml", "pyyaml==4.2b4", "rdflib", "docopt", "pathlib"]
 
 if sys.version_info < (3, 4):
     install_req += ["enum34"]


### PR DESCRIPTION
This PR
- upgrades the pyyaml dependency to the non-breaking beta version 4.2b4. Once a stable version is available, the dependencies should be updated again. Closes #291.
- removes the Python 3.4 build from the travis build list, since 3.4 will no longer be supported after March 2019.
- changes the Appveyor badge in `README` to the "G-Node" project build.
- adds minor typo fixes and comments to the `CONTRIBUTING` file.
