### PR TITLE
RDF Writer Formats

### DIFF
--- a/odml/tools/format_converter.py
+++ b/odml/tools/format_converter.py
@@ -119,6 +119,9 @@ class FormatConverter(object):
                 p, _ = os.path.splitext(output_path)
                 output_path = p + cls._conversion_formats[res_format]
             RDFWriter(odml.load(input_path)).write_file(output_path, res_format)
+        else:
+            raise ValueError("Format for output files is incorrect. "
+                             "Please choose from the list: {}".format(cls._conversion_formats.keys()))
 
     @staticmethod
     def _create_sub_directory(dir_path):

--- a/odml/tools/format_converter.py
+++ b/odml/tools/format_converter.py
@@ -6,6 +6,7 @@ import sys
 import odml
 from .rdf_converter import RDFWriter
 from .version_converter import VersionConverter
+from .utils import ConversionFormats
 
 try:
     unicode = unicode
@@ -14,23 +15,6 @@ except NameError:
 
 
 class FormatConverter(object):
-
-    _conversion_formats = {
-        'v1_1': '.xml',
-        'odml': '.odml',
-        # rdflib version "4.2.2" serialization formats
-        'xml': '.rdf',
-        'pretty-xml': '.rdf',
-        'trix': '.rdf',
-        'n3': '.n3',
-        'turtle': '.ttl',
-        'ttl': '.ttl',
-        'ntriples': '.nt',
-        'nt': '.nt',
-        'nt11': '.nt',
-        'trig': '.trig',
-        'json-ld': '.jsonld'
-    }
 
     @classmethod
     def convert(cls, args=None):
@@ -50,7 +34,7 @@ class FormatConverter(object):
         """
         parser = argparse.ArgumentParser(description="Convert directory with odml files to another format")
         parser.add_argument("input_dir", help="Path to input directory")
-        parser.add_argument("result_format", choices=list(cls._conversion_formats),
+        parser.add_argument("result_format", choices=list(ConversionFormats),
                             help="Format of output files")
         parser.add_argument("-out", "--output_dir", help="Path for output directory")
         parser.add_argument("-r", "--recursive", action="store_true",
@@ -70,11 +54,11 @@ class FormatConverter(object):
                            Possible choices: "v1_1" (converts to version 1.1 from version 1 xml)
                                              "odml" (converts to .odml from version 1.1 .xml files)
                                              "turtle", "nt" etc. (converts to rdf formats from version 1.1 .odml files)
-                                             (see full list of rdf serializers in FormatConverter._conversion_formats)
+                                             (see full list of rdf serializers in utils.ConversionFormats)
         """
-        if res_format not in cls._conversion_formats:
+        if res_format not in ConversionFormats:
             raise ValueError("Format for output files is incorrect. "
-                             "Please choose from the list: {}".format(list(cls._conversion_formats)))
+                             "Please choose from the list: {}".format(list(ConversionFormats)))
 
         cls._check_input_output_directory(input_dir, output_dir)
         input_dir = os.path.join(input_dir, '')
@@ -114,14 +98,14 @@ class FormatConverter(object):
                 p, _ = os.path.splitext(output_path)
                 output_path = p + ".odml"
             odml.save(odml.load(input_path), output_path)
-        elif res_format in cls._conversion_formats:
-            if not output_path.endswith(cls._conversion_formats[res_format]):
+        elif res_format in ConversionFormats:
+            if not output_path.endswith(ConversionFormats[res_format]):
                 p, _ = os.path.splitext(output_path)
-                output_path = p + cls._conversion_formats[res_format]
+                output_path = p + ConversionFormats[res_format]
             RDFWriter(odml.load(input_path)).write_file(output_path, res_format)
         else:
             raise ValueError("Format for output files is incorrect. "
-                             "Please choose from the list: {}".format(list(cls._conversion_formats)))
+                             "Please choose from the list: {}".format(list(ConversionFormats)))
 
     @staticmethod
     def _create_sub_directory(dir_path):

--- a/odml/tools/format_converter.py
+++ b/odml/tools/format_converter.py
@@ -74,7 +74,7 @@ class FormatConverter(object):
         """
         if res_format not in cls._conversion_formats:
             raise ValueError("Format for output files is incorrect. "
-                             "Please choose from the list: {}".format(cls._conversion_formats.keys()))
+                             "Please choose from the list: {}".format(list(cls._conversion_formats)))
 
         cls._check_input_output_directory(input_dir, output_dir)
         input_dir = os.path.join(input_dir, '')
@@ -121,7 +121,7 @@ class FormatConverter(object):
             RDFWriter(odml.load(input_path)).write_file(output_path, res_format)
         else:
             raise ValueError("Format for output files is incorrect. "
-                             "Please choose from the list: {}".format(cls._conversion_formats.keys()))
+                             "Please choose from the list: {}".format(list(cls._conversion_formats)))
 
     @staticmethod
     def _create_sub_directory(dir_path):

--- a/odml/tools/rdf_converter.py
+++ b/odml/tools/rdf_converter.py
@@ -212,10 +212,10 @@ class RDFWriter(object):
     def write_file(self, filename, rdf_format="turtle"):
         data = self.get_rdf_str(rdf_format)
         filename_ext = filename
-        if not filename.find("." + rdf_format):
-            filename_ext += "." + rdf_format
-        with open(filename_ext, "w") as file:
-            file.write(data)
+        if filename.find(self._conversion_formats.get(rdf_format)) < 0:
+            filename_ext += self._conversion_formats.get(rdf_format)
+        with open(filename_ext, "w") as wFile:
+            wFile.write(data)
 
 
 class RDFReader(object):

--- a/odml/tools/rdf_converter.py
+++ b/odml/tools/rdf_converter.py
@@ -13,6 +13,7 @@ from ..format import Format, Document, Section, Property
 from .dict_parser import DictReader
 from .parser_utils import ParserException
 from ..info import FORMAT_VERSION
+from .utils import RDFConversionFormats
 
 try:
     unicode = unicode
@@ -33,7 +34,7 @@ class RDFWriter(object):
 
     def __init__(self, odml_documents):
         """
-        :param odml_documents: list of odml documents 
+        :param odml_documents: list of odml documents
         """
         self.docs = odml_documents if not isinstance(odml_documents, odml.doc.BaseDocument) else [odml_documents]
         self.hub_root = None
@@ -56,21 +57,6 @@ class RDFWriter(object):
                     print(err)
                     return
 
-    _conversion_formats = {
-        # rdflib version "4.2.2" serialization formats
-        'xml': '.rdf',
-        'pretty-xml': '.rdf',
-        'trix': '.rdf',
-        'n3': '.n3',
-        'turtle': '.ttl',
-        'ttl': '.ttl',
-        'ntriples': '.nt',
-        'nt': '.nt',
-        'nt11': '.nt',
-        'trig': '.trig',
-        'json-ld': '.jsonld'
-    }
-
     def convert_to_rdf(self):
         self.hub_root = URIRef(odmlns.Hub)
         if self.docs:
@@ -81,9 +67,9 @@ class RDFWriter(object):
     def save_element(self, e, node=None):
         """
         Save the current element to the RDF graph
-        :param e: current element 
+        :param e: current element
         :param node: A node to pass the earlier created node to inner elements
-        :return: the RDF graph 
+        :return: the RDF graph
         """
         fmt = e.format()
 
@@ -197,23 +183,23 @@ class RDFWriter(object):
 
     def get_rdf_str(self, rdf_format="turtle"):
         """
-        Get converted into one of the supported formats data 
-        :param rdf_format: possible formats: 'xml', 'n3', 'turtle', 
-                                             'nt', 'pretty-xml', 'trix', 
+        Get converted into one of the supported formats data
+        :param rdf_format: possible formats: 'xml', 'n3', 'turtle',
+                                             'nt', 'pretty-xml', 'trix',
                                              'trig', 'nquads', 'json-ld'.
-               Full lists see in odml.tools.format_converter.FormatConverter._conversion_formats
+               Full lists see in utils.RDFConversionFormats
         :return: string object
         """
-        if rdf_format not in self._conversion_formats:
+        if rdf_format not in RDFConversionFormats:
             raise ValueError("odml.RDFWriter.get_rdf_str: Format for output files is incorrect. "
-                             "Please choose from the list: {}".format(list(self._conversion_formats)))
+                             "Please choose from the list: {}".format(list(RDFConversionFormats)))
         return self.convert_to_rdf().serialize(format=rdf_format).decode("utf-8")
 
     def write_file(self, filename, rdf_format="turtle"):
         data = self.get_rdf_str(rdf_format)
         filename_ext = filename
-        if filename.find(self._conversion_formats.get(rdf_format)) < 0:
-            filename_ext += self._conversion_formats.get(rdf_format)
+        if filename.find(RDFConversionFormats.get(rdf_format)) < 0:
+            filename_ext += RDFConversionFormats.get(rdf_format)
         with open(filename_ext, "w") as wFile:
             wFile.write(data)
 

--- a/odml/tools/rdf_converter.py
+++ b/odml/tools/rdf_converter.py
@@ -204,6 +204,9 @@ class RDFWriter(object):
                Full lists see in odml.tools.format_converter.FormatConverter._conversion_formats
         :return: string object
         """
+        if rdf_format not in self._conversion_formats:
+            raise ValueError("odml.RDFWriter.get_rdf_str: Format for output files is incorrect. "
+                             "Please choose from the list: {}".format(self._conversion_formats.keys()))
         return self.convert_to_rdf().serialize(format=rdf_format).decode("utf-8")
 
     def write_file(self, filename, rdf_format="turtle"):

--- a/odml/tools/rdf_converter.py
+++ b/odml/tools/rdf_converter.py
@@ -206,7 +206,7 @@ class RDFWriter(object):
         """
         if rdf_format not in self._conversion_formats:
             raise ValueError("odml.RDFWriter.get_rdf_str: Format for output files is incorrect. "
-                             "Please choose from the list: {}".format(self._conversion_formats.keys()))
+                             "Please choose from the list: {}".format(list(self._conversion_formats)))
         return self.convert_to_rdf().serialize(format=rdf_format).decode("utf-8")
 
     def write_file(self, filename, rdf_format="turtle"):

--- a/odml/tools/rdf_converter.py
+++ b/odml/tools/rdf_converter.py
@@ -56,6 +56,21 @@ class RDFWriter(object):
                     print(err)
                     return
 
+    _conversion_formats = {
+        # rdflib version "4.2.2" serialization formats
+        'xml': '.rdf',
+        'pretty-xml': '.rdf',
+        'trix': '.rdf',
+        'n3': '.n3',
+        'turtle': '.ttl',
+        'ttl': '.ttl',
+        'ntriples': '.nt',
+        'nt': '.nt',
+        'nt11': '.nt',
+        'trig': '.trig',
+        'json-ld': '.jsonld'
+    }
+
     def convert_to_rdf(self):
         self.hub_root = URIRef(odmlns.Hub)
         if self.docs:
@@ -193,7 +208,10 @@ class RDFWriter(object):
 
     def write_file(self, filename, rdf_format):
         data = self.get_rdf_str(rdf_format)
-        with open(filename, "w") as file:
+        filename_ext = filename
+        if not filename.find("." + rdf_format):
+            filename_ext += "." + rdf_format
+        with open(filename_ext, "w") as file:
             file.write(data)
 
 

--- a/odml/tools/rdf_converter.py
+++ b/odml/tools/rdf_converter.py
@@ -195,7 +195,7 @@ class RDFWriter(object):
     def __unicode__(self):
         return self.convert_to_rdf().serialize(format='turtle').decode("utf-8")
 
-    def get_rdf_str(self, rdf_format):
+    def get_rdf_str(self, rdf_format="turtle"):
         """
         Get converted into one of the supported formats data 
         :param rdf_format: possible formats: 'xml', 'n3', 'turtle', 
@@ -206,7 +206,7 @@ class RDFWriter(object):
         """
         return self.convert_to_rdf().serialize(format=rdf_format).decode("utf-8")
 
-    def write_file(self, filename, rdf_format):
+    def write_file(self, filename, rdf_format="turtle"):
         data = self.get_rdf_str(rdf_format)
         filename_ext = filename
         if not filename.find("." + rdf_format):

--- a/odml/tools/utils.py
+++ b/odml/tools/utils.py
@@ -1,0 +1,22 @@
+import copy
+
+RDFConversionFormats = {
+    # rdflib version "4.2.2" serialization formats
+    'xml': '.rdf',
+    'pretty-xml': '.rdf',
+    'trix': '.rdf',
+    'n3': '.n3',
+    'turtle': '.ttl',
+    'ttl': '.ttl',
+    'ntriples': '.nt',
+    'nt': '.nt',
+    'nt11': '.nt',
+    'trig': '.trig',
+    'json-ld': '.jsonld'
+}
+
+ConversionFormats = copy.deepcopy(RDFConversionFormats)
+ConversionFormats.update({
+    'v1_1': '.xml',
+    'odml': '.odml'
+})

--- a/test/test_rdf_writer.py
+++ b/test/test_rdf_writer.py
@@ -195,3 +195,9 @@ class TestRDFWriter(unittest.TestCase):
         self.assertEqual(len(list(w.g.subjects(predicate=odmlns.hasDtype, object=Literal(p_dtype)))), 1)
         self.assertEqual(len(list(w.g.subjects(predicate=odmlns.hasValueOrigin, object=Literal(p_value_origin)))), 1)
         self.assertEqual(len(list(w.g.subjects(predicate=odmlns.hasReference, object=Literal(p_ref)))), 1)
+
+    def test_get_rdf_string(self):
+        w = RDFWriter([self.doc1])
+        w.get_rdf_str()
+        with self.assertRaises(ValueError):
+            w.get_rdf_str("abc")


### PR DESCRIPTION
With this pull request:

- The default format for RDFWriter is set to turtle. Closes #214 
- The RDF Writer checks for a given file extension within the RDF document name, if accidentally given there. Closes #213 
- The RDF Writer throws a ValueError, if an unsupported RDF format is given (with respective test). Closes #215 