### PR TITLE
CLI script to locally view odml files via webbrowser

### DIFF
--- a/odml/scripts/odml_view.py
+++ b/odml/scripts/odml_view.py
@@ -1,15 +1,21 @@
-"""odmlView
+"""odmlview
 
-odmlView sets up a minimal webserver and serves
-and renders odml files locally from the directory
-the server is started in.
+odmlview sets up a minimal webserver to view odml files saved in the
+XML format via the webbrowser. After it started, the webserver will
+open a new tab in the default webbrowser and display the content of
+the directory the server was started from. odML files can then be
+viewed from there.
+To properly render XML, an odML file may contain the element
+'<?xml-stylesheet  type="text/xsl" href="odmlTerms.xsl"?>' where the
+'odmlTerms.xsl' stylesheet should reside in the same directory as the
+odML file to be rendered. By using the '--fetch' flag the latest version
+of this stylesheet will be downloaded from 'templates.g-node.org' to
+the current directory when starting up the service.
 
-Usage: odmlView [-d DIRECTORY] [-p PORT]
 Usage: odmlview [-p PORT] [--fetch]
 
 Options:
-    -p PORT         Port the server will use.
-                    Default is port 8000.
+    -p PORT         Port the server will use. Default: 8000
     --fetch         Fetch latest stylesheet from templates.g-node.org
                     to current directory
     -h --help       Show this screen
@@ -57,6 +63,7 @@ def run(port=PORT):
     with socketserver.TCPServer(server_address, handler) as httpd:
         webbrowser.open_new_tab('http://localhost:%s' % port)
         try:
+            print("You can end the server by pressing Ctrl+C")
             httpd.serve_forever()
         except KeyboardInterrupt:
             print("Received Keyboard interrupt, shutting down")

--- a/odml/scripts/odml_view.py
+++ b/odml/scripts/odml_view.py
@@ -16,7 +16,13 @@ Options:
     --version       Show version
 """
 
-import http.server as hs
+import os
+try:
+    import http.server as hs
+except ImportError:
+    print("This script is only supported with Python 3")
+    exit(-1)
+
 import socketserver
 import sys
 import urllib.request as urllib2

--- a/odml/scripts/odml_view.py
+++ b/odml/scripts/odml_view.py
@@ -75,6 +75,7 @@ def run(port=PORT, extensions=None):
 
     server_address = ('', port)
 
+    socketserver.TCPServer.allow_reuse_address = True
     with socketserver.TCPServer(server_address, handler) as httpd:
         webbrowser.open_new_tab('http://localhost:%s' % port)
         try:
@@ -82,6 +83,7 @@ def run(port=PORT, extensions=None):
             httpd.serve_forever()
         except KeyboardInterrupt:
             print("[Info] Received Keyboard interrupt, shutting down")
+            httpd.shutdown()
             httpd.server_close()
 
 

--- a/odml/scripts/odml_view.py
+++ b/odml/scripts/odml_view.py
@@ -16,11 +16,26 @@ Options:
 import http.server as hs
 import socketserver
 import sys
+import urllib.request as urllib2
 import webbrowser
 
 from docopt import docopt
 
 PORT = 8000
+REPOSITORY = "https://templates.g-node.org/_resources/"
+STYLESHEET = "odmlTerms.xsl"
+
+
+def fetch_stylesheet():
+    try:
+        data = urllib2.urlopen("%s%s" % (REPOSITORY, STYLESHEET)).read()
+        data = data.decode("utf-8")
+    except Exception as e:
+        print("failed loading '%s%s': %s" % (REPOSITORY, STYLESHEET, e))
+        return
+
+    with open(STYLESHEET, "w") as fp:
+        fp.write(str(data))
 
 
 def run(port=PORT):

--- a/odml/scripts/odml_view.py
+++ b/odml/scripts/odml_view.py
@@ -1,0 +1,51 @@
+"""odmlView
+
+odmlView sets up a minimal webserver and serves
+and renders odml files locally from the directory
+the server is started in.
+
+Usage: odmlView [-d DIRECTORY] [-p PORT]
+
+Options:
+    -p PORT         Port the server will use.
+                    Default is port 8000.
+    -h --help       Show this screen.
+    --version       Show version.
+"""
+
+import http.server as hs
+import socketserver
+import sys
+import webbrowser
+
+from docopt import docopt
+
+PORT = 8000
+
+
+def run(port=PORT):
+    handler = hs.SimpleHTTPRequestHandler
+    # files with odML extensions should be interpreted as XML
+    handler.extensions_map.update({'.odml': 'application/xml'})
+
+    server_address = ('', port)
+
+    with socketserver.TCPServer(server_address, handler) as httpd:
+        webbrowser.open_new_tab('http://localhost:%s' % port)
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            print("Received Keyboard interrupt, shutting down")
+            httpd.server_close()
+
+
+def main(args=None):
+    parser = docopt(__doc__, argv=args, version="0.1.0")
+
+    server_port = int(parser['-p']) if parser['-p'] else PORT
+
+    run(server_port)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/odml/scripts/odml_view.py
+++ b/odml/scripts/odml_view.py
@@ -5,12 +5,15 @@ and renders odml files locally from the directory
 the server is started in.
 
 Usage: odmlView [-d DIRECTORY] [-p PORT]
+Usage: odmlview [-p PORT] [--fetch]
 
 Options:
     -p PORT         Port the server will use.
                     Default is port 8000.
-    -h --help       Show this screen.
-    --version       Show version.
+    --fetch         Fetch latest stylesheet from templates.g-node.org
+                    to current directory
+    -h --help       Show this screen
+    --version       Show version
 """
 
 import http.server as hs
@@ -56,6 +59,10 @@ def run(port=PORT):
 
 def main(args=None):
     parser = docopt(__doc__, argv=args, version="0.1.0")
+
+    # Fetch stylesheet
+    if parser['--fetch'] and not os.path.exists(STYLESHEET):
+        fetch_stylesheet()
 
     server_port = int(parser['-p']) if parser['-p'] else PORT
 

--- a/odml/scripts/odml_view.py
+++ b/odml/scripts/odml_view.py
@@ -42,6 +42,10 @@ STYLESHEET = "odmlTerms.xsl"
 
 
 def download_file(repo, filename):
+    """
+    download_file fetches 'filename' from url 'repo' and
+    saves it in the current directory as file 'filename'.
+    """
     try:
         data = urllib2.urlopen("%s%s" % (repo, filename)).read()
         data = data.decode("utf-8")
@@ -54,6 +58,16 @@ def download_file(repo, filename):
 
 
 def run(port=PORT, extensions=None):
+    """
+    run starts a simple webserver on localhost serving the current directory.
+    Once started, it will open a tab on the default webbrowser and will continue
+    to serve until manually stopped.
+
+    :param port: server port
+    :param extensions: dictionary containing additional file extension - mime type
+                       mappings the server should be aware of.
+                       e.g. {'.xml': 'application/xml'}
+    """
     handler = hs.SimpleHTTPRequestHandler
 
     if extensions:

--- a/odml/scripts/odml_view.py
+++ b/odml/scripts/odml_view.py
@@ -41,20 +41,21 @@ REPOSITORY = "https://templates.g-node.org/_resources/"
 STYLESHEET = "odmlTerms.xsl"
 
 
-def fetch_stylesheet():
+def download_file(repo, filename):
     try:
-        data = urllib2.urlopen("%s%s" % (REPOSITORY, STYLESHEET)).read()
+        data = urllib2.urlopen("%s%s" % (repo, filename)).read()
         data = data.decode("utf-8")
-    except Exception as e:
-        print("failed loading '%s%s': %s" % (REPOSITORY, STYLESHEET, e))
+    except Exception as err:
+        print("[Warning] Failed loading '%s%s': %s" % (repo, filename, err))
         return
 
-    with open(STYLESHEET, "w") as fp:
-        fp.write(str(data))
+    with open(filename, "w") as local_file:
+        local_file.write(str(data))
 
 
 def run(port=PORT):
     handler = hs.SimpleHTTPRequestHandler
+
     # files with odML extensions should be interpreted as XML
     handler.extensions_map.update({'.odml': 'application/xml'})
 
@@ -63,10 +64,10 @@ def run(port=PORT):
     with socketserver.TCPServer(server_address, handler) as httpd:
         webbrowser.open_new_tab('http://localhost:%s' % port)
         try:
-            print("You can end the server by pressing Ctrl+C")
+            print("[Info] The server can be stopped by pressing Ctrl+C")
             httpd.serve_forever()
         except KeyboardInterrupt:
-            print("Received Keyboard interrupt, shutting down")
+            print("[Info] Received Keyboard interrupt, shutting down")
             httpd.server_close()
 
 
@@ -75,7 +76,8 @@ def main(args=None):
 
     # Fetch stylesheet
     if parser['--fetch'] and not os.path.exists(STYLESHEET):
-        fetch_stylesheet()
+        print("[Info] Downloading stylesheet '%s'" % STYLESHEET)
+        download_file(REPOSITORY, STYLESHEET)
 
     server_port = int(parser['-p']) if parser['-p'] else PORT
 

--- a/odml/scripts/odml_view.py
+++ b/odml/scripts/odml_view.py
@@ -1,7 +1,7 @@
 """odmlview
 
 odmlview sets up a minimal webserver to view odml files saved in the
-XML format via the webbrowser. After it started, the webserver will
+XML format via the webbrowser. After it is started, the webserver will
 open a new tab in the default webbrowser and display the content of
 the directory the server was started from. odML files can then be
 viewed from there.

--- a/odml/scripts/odml_view.py
+++ b/odml/scripts/odml_view.py
@@ -53,11 +53,11 @@ def download_file(repo, filename):
         local_file.write(str(data))
 
 
-def run(port=PORT):
+def run(port=PORT, extensions=None):
     handler = hs.SimpleHTTPRequestHandler
 
-    # files with odML extensions should be interpreted as XML
-    handler.extensions_map.update({'.odml': 'application/xml'})
+    if extensions:
+        handler.extensions_map.update(extensions)
 
     server_address = ('', port)
 
@@ -81,7 +81,10 @@ def main(args=None):
 
     server_port = int(parser['-p']) if parser['-p'] else PORT
 
-    run(server_port)
+    # files with odML file extensions should be interpreted as XML
+    extensions = {'.odml': 'application/xml'}
+
+    run(server_port, extensions)
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,6 @@ setup(
     classifiers=CLASSIFIERS,
     license="BSD",
     entry_points={'console_scripts': ['odmltordf=odml.scripts.odml_to_rdf:main',
-                                      'odmlconversion=odml.scripts.odml_conversion:main']}
+                                      'odmlconversion=odml.scripts.odml_conversion:main',
+                                      'odmlview=odml.scripts.odml_view:main']}
 )


### PR DESCRIPTION
Currently most web browsers no longer support viewing local files, that include further local files; see [here](https://developer.mozilla.org/en-US/docs/Archive/Misc_top_level/Same-origin_policy_for_file:_URIs) for additional details.

odML XML files can be nicely rendered by stylesheets, but with the changes described above, this no longer works as smoothly as it did before on a local machine.

This PR therefore introduces another CLI script, `odmlview`, that starts up a local webserver. This webserver is able to properly serve odML XML files from a local directory and render them correctly, if the appropriate stylesheets are present in the same directory.

The CLI script provides an option (`--fetch`) to download the most commonly used xsl stylesheet, `odmlTerms.xsl` from `https://templates.g-node.org/_resources` to the local directory, to make sure that no stylesheet has to be shipped with python-odml, but potential users have easy access to it:

```
odmlview sets up a minimal webserver to view odml files saved in the
XML format via the webbrowser. After it started, the webserver will
open a new tab in the default webbrowser and display the content of
the directory the server was started from. odML files can then be
viewed from there.
To properly render XML, an odML file may contain the element
'<?xml-stylesheet  type="text/xsl" href="odmlTerms.xsl"?>' where the
'odmlTerms.xsl' stylesheet should reside in the same directory as the
odML file to be rendered. By using the '--fetch' flag the latest version
of this stylesheet will be downloaded from 'templates.g-node.org' to
the current directory when starting up the service.

Usage: odmlview [-p PORT] [--fetch]

Options:
    -p PORT         Port the server will use. Default: 8000
    --fetch         Fetch latest stylesheet from templates.g-node.org
                    to current directory
    -h --help       Show this screen
    --version       Show version
```
