### PR TITLE
Preparation for version 1.4.3 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,21 @@ matrix:
       python: "3.5"
     - os: linux
       python: "3.6"
+    - os: linux
+      python: "3.7"
+      dist: xenial
+    - os: linux
+      python: "3.8"
+      dist: xenial
 
     - os: osx
       language: generic
       env:
         - OSXENV=3.6.0
+    - os: osx
+      language: generic
+      env:
+        - OSXENV=3.7.0
     - os: osx
       language: generic
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ matrix:
   include:
     - os: linux
       python: "2.7"
-      env: COVERALLS=1
     - os: linux
       python: "3.5"
     - os: linux
       python: "3.6"
+      env: COVERALLS=1
     - os: linux
       python: "3.7"
       dist: xenial

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ of this stylesheet will be downloaded from `templates.g-node.org` to
 the current directory when starting up the service.
 ```
 
+## Console script 'odmlconversion' is renamed
+The console script `odmlconversion` is renamed to `odmlconvert`. For backwards compatibility the script will be available as `odmlconversion` with a deprecation notice.
+
 ## 'pyyaml' dependency update
 The `pyyaml` dependency has been changed to the non-breaking beta version 4.2b4. See issue #291 for details.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,49 @@ until the next release.
 
 # Latest changes in master
 
-...
+# Version 1.4.3
+
+## Introduction of odML templates support and update in odML terminology handling
+
+Support for importing and working with odML templates is added:
+- the core library now features the `TemplateHandler` class to handle import and usage of odML templates.
+- the default URL to fetch templates from has been set to `https://templates.g-node.org`.
+- all terminology URLs are updated to the new terminology deployment at `https://terminology.g-node.org`.
+
+## Additional console script: 'odmlview'
+
+Currently most web browsers no longer support viewing local files that include further local files like stylesheets; check [here](https://developer.mozilla.org/en-US/docs/Archive/Misc_top_level/Same-origin_policy_for_file:_URIs) for additional details. The console script `odmlview` provides a local webserver that is able to properly serve odML XML files from a local directory and render them correctly, if the appropriate stylesheets are present in the same directory.
+
+```
+'odmlview' sets up a minimal webserver to view odml files saved in the
+XML format via the webbrowser. After it is started, the webserver will
+open a new tab in the default webbrowser and display the content of
+the directory the server was started from. odML files can then be
+viewed from there.
+To properly render XML, an odML file may contain the element
+'<?xml-stylesheet  type="text/xsl" href="odmlDocument.xsl"?>' where the
+'odmlDocument.xsl' stylesheet should reside in the same directory as the
+odML file to be rendered. By using the '--fetch' flag the latest version
+of this stylesheet will be downloaded from `templates.g-node.org` to
+the current directory when starting up the service.
+```
+
+## 'pyyaml' dependency update
+The `pyyaml` dependency has been changed to the non-breaking beta version 4.2b4. See issue #291 for details.
+
+## Minor changes, updates and fixes
+- odML entity IDs are automatically added when converting from odML version 1 to odMl version 1.1 for `Document`, `Section` and `Property` elements. If an ID already exists, it stays the same, if it is compatible with the Python UUID types. Otherwise (also if empty) a new ID is created for the odML entity.
+- `Property` can now be set as `int` with value `0`. See issue #314 for details.
+- appending and extending of `Property` values of dtypes `person`, `url` and `text` is now possible. See issue #318 for details.
+- the default `RDFWriter` format is set to `turtle`. See issue #214 for details.
+- the `RDFWriter` now checks for a given file extension within the RDF document name if accidentally given there. See issue #213 for details.
+- the `RDFWriter` now throws a `ValueError` if an unsupported RDF format is given. See issue #215 for details.
+- the `XMLReader` now properly handles entity creation failures when started with option `ignore_errors=True`. See issue #276 for details.
+- the `pprint` method has been added to `Document` to print while document section. See issue #319 for details.
+- the README file has been changed from `rst` to the `md` format.
+- the current tutorial has been updated to include latest changes.
+- the automated builds have been updated to include Python versions 3.7 and 3.8; version 3.4 has been removed since it is no longer supported on travis.
+
 
 # Version 1.4.2
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/br7pe6atlwdg5618/branch/master?svg=true)](https://ci.appveyor.com/project/G-Node/python-odml/branch/master)
 ![Test coverage](https://coveralls.io/repos/github/G-Node/python-odml/badge.svg?branch=master)
 [![PyPI version](https://img.shields.io/pypi/v/odml.svg)](https://pypi.org/project/odML/)
+[![Read the Docs](https://img.shields.io/readthedocs/python-odml)](https://python-odml.readthedocs.io/en/latest/)
+
 
 # odML (Open metaData Markup Language) core library
 
@@ -15,8 +17,43 @@ with the version control system **git**, but still want to use it, have a look a
 documentation available on the [git-scm website](https://git-scm.com/).
 
 
-# Breaking changes
+# odML Project page
 
+More information about the project including related projects as well as tutorials and
+examples can be found at our odML [project page](https://g-node.github.io/python-odml).
+
+
+# Getting started
+
+## Installation
+
+*python-odml* is most conveniently installed via pip.
+
+```
+pip install odml
+```
+
+## Tutorial and examples
+
+- We have assembled a set of
+ [tutorials](http://github.com/G-Node/python-odml/blob/master/doc/tutorial.rst "Python Tutorial").
+
+## Python convenience scripts
+
+The Python installation features multiple convenience commandline scripts.
+
+- `odmlconversion`: Converts odML files of previous file versions into the current one.
+- `odmltordf`: Converts odML files to the supported RDF version of odML.
+- `odmlview`: Render and browse local XML odML files in the webbrowser.
+
+All scripts provide detailed usage descriptions by adding the `help` flag to the command.
+
+    odmlconversion -h
+    odmltordf -h
+    odmlview -h
+
+
+# Breaking changes
 
 odML Version 1.4 introduced breaking format and API changes compared to the previous
 versions of odML. Files saved in the previous format versions can be converted to a 1.4
@@ -57,21 +94,6 @@ release notes](https://github.com/G-Node/python-odml/releases).
   * lib32z1-dev
 
 
-# Installation
-
-The simplest way to install Python-odML is from PyPI using the pip tool:
-
-
-```
-  $ pip install odml
-```
-
-On Ubuntu, the pip package manager is available in the repositories as ```python-pip```.
-
-If this method is used, the appropriate Python dependencies are downloaded and installed
-automatically.
-
-
 # Building from source
 
 To download the Python-odML library please either use git and clone
@@ -95,14 +117,11 @@ To install the Python-odML library, enter the corresponding directory and run:
 **Note** The master branch is our current development branch, not all features might be
 working as expected. Use the release tags instead.
 
-# odML Project page
-
-More information about the project including related projects as well as tutorials and
-examples can be found at our odML [project page](https://g-node.github.io/python-odml).
 
 # Contributing and Governance
 
 See the [CONTRIBUTING](CONTIBUTING.md) document for more information on this.
+
 
 # Bugs & Questions
 

--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ pip install odml
 
 The Python installation features multiple convenience commandline scripts.
 
-- `odmlconversion`: Converts odML files of previous file versions into the current one.
+- `odmlconvert`: Converts odML files of previous file versions into the current one.
 - `odmltordf`: Converts odML files to the supported RDF version of odML.
 - `odmlview`: Render and browse local XML odML files in the webbrowser.
 
 All scripts provide detailed usage descriptions by adding the `help` flag to the command.
 
-    odmlconversion -h
+    odmlconvert -h
     odmltordf -h
     odmlview -h
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,12 +6,16 @@ environment:
       PYVER: "3.5"
     - PYTHON: "C:\\Python36"
       PYVER: "3.6"
+    - PYTHON: "C:\\Python37"
+      PYVER: "3.7"
     - PYTHON: "C:\\Python27-x64"
       PYVER: "2.7"
     - PYTHON: "C:\\Python35-x64"
       PYVER: "3.5"
     - PYTHON: "C:\\Python36-x64"
       PYVER: "3.6"
+    - PYTHON: "C:\\Python37-x64"
+      PYVER: "3.7"
 
 build: false
 

--- a/doc/tools.rst
+++ b/doc/tools.rst
@@ -55,3 +55,30 @@ RDFConverter
    :members:
    :inherited-members:
    :undoc-members:
+
+.. _cli_scripts:
+
+Command line scripts
+====================
+Several cli convenience scripts are automatically installed and are available from the command line.
+
+odML conversion script
+----------------------
+.. automodule:: odml.scripts.odml_convert
+   :members:
+   :inherited-members:
+   :undoc-members:
+
+odML to RDF script
+------------------
+.. automodule:: odml.scripts.odml_to_rdf
+   :members:
+   :inherited-members:
+   :undoc-members:
+
+odML view (browse odml files locally)
+-------------------------------------
+.. automodule:: odml.scripts.odml_view
+   :members:
+   :inherited-members:
+   :undoc-members:

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,13 +77,13 @@ pip install odml
 
 The Python installation features multiple convenience commandline scripts.
 
-- `odmlconversion`: Converts odML files of previous file versions into the current one.
+- `odmlconvert`: Converts odML files of previous file versions into the current one.
 - `odmltordf`: Converts odML files to the supported RDF version of odML.
 - `odmlview`: Render and browse local XML odML files in the webbrowser.
 
 All scripts provide detailed usage descriptions by adding the `help` flag to the command.
 
-    odmlconversion -h
+    odmlconvert -h
     odmltordf -h
     odmlview -h
 

--- a/odml/info.json
+++ b/odml/info.json
@@ -1,8 +1,8 @@
 {
-  "VERSION": "1.4.2",
+  "VERSION": "1.4.3",
   "FORMAT_VERSION": "1.1",
   "AUTHOR": "Hagen Fritsch, Jan Grewe, Christian Kellner, Achilleas Koutsou, Michael Sonntag, Lyuba Zehl",
-  "COPYRIGHT": "(c) 2011-2018, German Neuroinformatics Node",
+  "COPYRIGHT": "(c) 2011-2019, German Neuroinformatics Node",
   "CONTACT": "dev@g-node.org",
   "HOMEPAGE": "https://github.com/G-Node/python-odml",
   "CLASSIFIERS": [
@@ -11,6 +11,8 @@
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
     "Topic :: Scientific/Engineering",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: BSD License"

--- a/odml/scripts/odml_convert.py
+++ b/odml/scripts/odml_convert.py
@@ -1,12 +1,12 @@
-"""odmlConversion
+"""odmlConvert
 
-odmlConversion searches for odML files within a provided SEARCHDIR
+odmlConvert searches for odML files within a provided SEARCHDIR
 and converts them to the newest odML format version.
 Original files will never be overwritten. New files will be
 written either to a new directory at the current or a specified
 location.
 
-Usage: odmlconversion [-r] [-o OUT] SEARCHDIR
+Usage: odmlconvert [-r] [-o OUT] SEARCHDIR
 
 Arguments:
     SEARCHDIR       Directory to search for odML files.
@@ -121,6 +121,18 @@ def main(args=None):
 
     print(report.getvalue())
     report.close()
+
+
+def dep_note(args=None):
+    """
+    Print deprecation warning and call main function.
+
+    :param args: Command line arguments
+    """
+
+    print("\n[DEPRECATION WARNING] 'odmlconversion' will be removed with \n"
+          "the next version release. Please use 'odmlconvert' instead.\n")
+    main(args)
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
     classifiers=CLASSIFIERS,
     license="BSD",
     entry_points={'console_scripts': ['odmltordf=odml.scripts.odml_to_rdf:main',
-                                      'odmlconversion=odml.scripts.odml_conversion:main',
+                                      'odmlconversion=odml.scripts.odml_convert:dep_note',
+                                      'odmlconvert=odml.scripts.odml_convert:main',
                                       'odmlview=odml.scripts.odml_view:main']}
 )


### PR DESCRIPTION
This PR prepares for the release of version 1.4.3. It
- updates the release number, copyright date and the classifiers in `info.json`.
- adds all changes since v1.4.2 to the `CHANGELOG`.
- restructures the `README` file and adds a badge for easy access to readthedocs.
- updates the travis build matrix to include Python 3.7 and 3.8 builds and the appveyor build matrix to include Python 3.7 builds.
- the CLI script `odmlconversion` is renamed to `odmlconvert`. All documentation is updated, the script is still available under its previous name `odmlconversion` with a deprecation notice.
