### PR TITLE
Minor fixes and cleanup

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
-include LICENSE
-include README.rst
+include LICENSE README.md CHANGELOG.md
 include odml/info.json
-include odml/resources/section_subclasses.yaml
-include odml/resources/odml-ontology.ttl
+recursive-include odml/resources *
+recursive-include test/resources *

--- a/odml/__init__.py
+++ b/odml/__init__.py
@@ -1,3 +1,7 @@
+import warnings
+
+from sys import version_info
+
 _property = property
 
 from . import doc
@@ -7,6 +11,11 @@ from .dtypes import DType
 from .fileio import load, save, display
 from .info import VERSION
 from .tools.parser_utils import SUPPORTED_PARSERS as PARSERS
+
+if version_info.major < 3 or version_info.major == 3 and version_info.minor < 6:
+    msg = "The '%s' package is not tested with your Python version. " % __name__
+    msg += "Please consider upgrading to the latest Python distribution."
+    warnings.warn(msg)
 
 __version__ = VERSION
 

--- a/odml/__init__.py
+++ b/odml/__init__.py
@@ -1,6 +1,6 @@
 import warnings
 
-from sys import version_info
+from sys import version_info as _python_version
 
 _property = property
 
@@ -12,7 +12,7 @@ from .fileio import load, save, display
 from .info import VERSION
 from .tools.parser_utils import SUPPORTED_PARSERS as PARSERS
 
-if version_info.major < 3 or version_info.major == 3 and version_info.minor < 6:
+if _python_version.major < 3 or _python_version.major == 3 and _python_version.minor < 6:
     msg = "The '%s' package is not tested with your Python version. " % __name__
     msg += "Please consider upgrading to the latest Python distribution."
     warnings.warn(msg)

--- a/odml/dtypes.py
+++ b/odml/dtypes.py
@@ -328,12 +328,18 @@ def tuple_get(string, count=None):
     """
     if not string:
         return None
+
     string = string.strip()
-    assert string.startswith("(") and string.endswith(")")
+    if not (string.startswith("(") and string.endswith(")")):
+        msg = "Tuple value misses brackets: '%s'" % string
+        raise ValueError(msg)
+
     string = string[1:-1]
     res = [x.strip() for x in string.split(";")]
-    if count is not None:  # be strict
-        assert len(res) == count
+    if count is not None and not len(res) == count:
+        msg = "%s-tuple value does not match required item length" % count
+        raise ValueError(msg)
+
     return res
 
 

--- a/odml/tools/converters/version_converter.py
+++ b/odml/tools/converters/version_converter.py
@@ -64,7 +64,7 @@ class VersionConverter(object):
 
     def _parse_yaml(self):
         with open(self.filename) as file:
-            parsed_doc = yaml.load(file)
+            parsed_doc = yaml.safe_load(file)
 
         return self._parse_dict_document(parsed_doc)
 

--- a/odml/tools/dict_parser.py
+++ b/odml/tools/dict_parser.py
@@ -5,7 +5,7 @@ Both handle the conversion of odML documents from and to Python dictionary objec
 
 from .. import format as odmlfmt
 from ..info import FORMAT_VERSION
-from .parser_utils import InvalidVersionException, ParserException
+from .parser_utils import InvalidVersionException, ParserException, odml_tuple_export
 
 
 class DictWriter:
@@ -107,8 +107,8 @@ class DictWriter:
                     elif (tag == []) or tag:  # Even if 'values' is empty, allow '[]'
                         # Custom odML tuples require special handling.
                         if attr == "values" and prop.dtype and \
-                                prop.dtype.endswith("-tuple") and len(prop.values) > 0:
-                            prop_dict["value"] = "(%s)" % ";".join(prop.values[0])
+                                prop.dtype.endswith("-tuple") and prop.values:
+                            prop_dict["value"] = odml_tuple_export(prop.values)
                         else:
                             # Always use the arguments key attribute name when saving
                             prop_dict[i] = tag

--- a/odml/tools/parser_utils.py
+++ b/odml/tools/parser_utils.py
@@ -34,3 +34,24 @@ class InvalidVersionException(ParserException):
     Exception wrapper to indicate a non-compatible odML version.
     """
     pass
+
+
+def odml_tuple_export(odml_tuples):
+    """
+    Converts odml style tuples to a parsable string representation.
+    Every tuple is represented by brackets '()'. The individual elements of a tuple are
+    separated by a semicolon ';'. The individual tuples are separated by a comma ','.
+    An odml 3-tuple list of 2 tuples would be serialized to: "[(11;12;13),(21;22;23)]".
+
+    :param odml_tuples: List of odml style tuples.
+    :return: string
+    """
+    str_tuples = ""
+    for val in odml_tuples:
+        str_val = ";".join(val)
+        if str_tuples:
+            str_tuples = "%s,(%s)" % (str_tuples, str_val)
+        else:
+            str_tuples = "(%s)" % str_val
+
+    return "[%s]" % str_tuples

--- a/odml/tools/rdf_converter.py
+++ b/odml/tools/rdf_converter.py
@@ -46,7 +46,7 @@ def load_rdf_subclasses():
 
     with open(subclass_file, "r") as yaml_file:
         try:
-            section_subclasses = yaml.load(yaml_file)
+            section_subclasses = yaml.safe_load(yaml_file)
         except yaml.parser.ParserError as err:
             print("[Error] Loading RDF subclass file: %s" % err)
 

--- a/odml/tools/xmlparser.py
+++ b/odml/tools/xmlparser.py
@@ -22,7 +22,7 @@ except ImportError:
 
 from .. import format as ofmt
 from ..info import FORMAT_VERSION
-from .parser_utils import InvalidVersionException, ParserException
+from .parser_utils import InvalidVersionException, ParserException, odml_tuple_export
 
 try:
     unicode = unicode
@@ -121,8 +121,8 @@ class XMLWriter:
                 continue
             if isinstance(fmt, ofmt.Property.__class__) and k == "value":
                 # Custom odML tuples require special handling for save loading from file.
-                if curr_el.dtype and curr_el.dtype.endswith("-tuple") and len(val) > 0:
-                    ele = E(k, "(%s)" % ";".join(val[0]))
+                if curr_el.dtype and curr_el.dtype.endswith("-tuple") and val:
+                    ele = E(k, odml_tuple_export(val))
                 else:
                     ele = E(k, to_csv(val))
                 cur.append(ele)

--- a/test/test_dtypes.py
+++ b/test/test_dtypes.py
@@ -213,10 +213,10 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(typ.tuple_get("(39.12; 67.19)"), ["39.12", "67.19"])
 
         # Test fail on missing parenthesis.
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             _ = typ.tuple_get("fail")
         # Test fail on mismatching element count and count number.
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             _ = typ.tuple_get("(1; 2; 3)", 2)
 
     def test_dtype_none(self):

--- a/test/test_dtypes.py
+++ b/test/test_dtypes.py
@@ -1,10 +1,24 @@
 import datetime
 import unittest
 
+from sys import version_info
+
 import odml.dtypes as typ
 
 
 class TestTypes(unittest.TestCase):
+
+    def assertLocalRegExp(self, text, regular_expression):
+        """
+        Python 2 is dead and assertRegexpMatches is deprecated and
+        will be removed, but keep compatibility until py 2 support is
+        fully dropped.
+        """
+
+        if version_info.major < 3:
+            self.assertRegexpMatches(text, regular_expression)
+        else:
+            self.assertRegex(text, regular_expression)
 
     def setUp(self):
         pass
@@ -36,8 +50,8 @@ class TestTypes(unittest.TestCase):
         self.assertIsInstance(typ.date_get(""), datetime.date)
 
         re = "^[0-9]{4}-(0[1-9]|1[0-2])-([0-2][0-9]|3[0-1])$"
-        self.assertRegexpMatches(typ.date_get(None).strftime(typ.FORMAT_DATE), re)
-        self.assertRegexpMatches(typ.date_get("").strftime(typ.FORMAT_DATE), re)
+        self.assertLocalRegExp(typ.date_get(None).strftime(typ.FORMAT_DATE), re)
+        self.assertLocalRegExp(typ.date_get("").strftime(typ.FORMAT_DATE), re)
 
         date = datetime.date(2011, 12, 1)
         date_string = '2011-12-01'
@@ -68,8 +82,8 @@ class TestTypes(unittest.TestCase):
         self.assertIsInstance(typ.time_get(""), datetime.time)
 
         re = "^[0-5][0-9]:[0-5][0-9]:[0-5][0-9]$"
-        self.assertRegexpMatches(typ.time_get(None).strftime(typ.FORMAT_TIME), re)
-        self.assertRegexpMatches(typ.time_get("").strftime(typ.FORMAT_TIME), re)
+        self.assertLocalRegExp(typ.time_get(None).strftime(typ.FORMAT_TIME), re)
+        self.assertLocalRegExp(typ.time_get("").strftime(typ.FORMAT_TIME), re)
 
         time = datetime.time(12, 34, 56)
         time_string = '12:34:56'
@@ -101,8 +115,8 @@ class TestTypes(unittest.TestCase):
 
         re = "^[0-9]{4}-(0[1-9]|1[0-2])-([0-2][0-9]|3[0-1]) " \
              "[0-5][0-9]:[0-5][0-9]:[0-5][0-9]$"
-        self.assertRegexpMatches(typ.datetime_get(None).strftime(typ.FORMAT_DATETIME), re)
-        self.assertRegexpMatches(typ.datetime_get("").strftime(typ.FORMAT_DATETIME), re)
+        self.assertLocalRegExp(typ.datetime_get(None).strftime(typ.FORMAT_DATETIME), re)
+        self.assertLocalRegExp(typ.datetime_get("").strftime(typ.FORMAT_DATETIME), re)
 
         date = datetime.datetime(2011, 12, 1, 12, 34, 56)
         date_string = '2011-12-01 12:34:56'

--- a/test/test_dtypes_integration.py
+++ b/test/test_dtypes_integration.py
@@ -324,34 +324,84 @@ class TestTypesIntegration(unittest.TestCase):
         self.assertEqual(self.doc, ydoc)
 
     def test_tuple(self):
+        # test single tuple value
         val_type = "3-tuple"
         val_in = "(1; 1; 1)"
-        val_odml = ["1", "1", "1"]
+        val_odml = [["1", "1", "1"]]
 
         parent_sec = self.doc.sections[0]
-        _ = odml.Property(name="tuple test single", dtype=val_type,
-                          value=val_in, parent=parent_sec)
+        sec_name = parent_sec.name
+        prop_name = "tuple_test_single"
+        _ = odml.Property(name=prop_name, dtype=val_type,
+                          values=val_in, parent=parent_sec)
 
         # Test correct json save and load.
         odml.save(self.doc, self.json_file, "JSON")
         jdoc = odml.load(self.json_file, "JSON")
 
-        self.assertEqual(jdoc.sections[0].properties[0].dtype, val_type)
-        self.assertEqual(jdoc.sections[0].properties[0].values, [val_odml])
+        self.assertEqual(jdoc.sections[sec_name].properties[prop_name].dtype, val_type)
+        self.assertEqual(jdoc.sections[sec_name].properties[prop_name].values, val_odml)
+        self.assertEqual(jdoc.sections[sec_name].properties[prop_name].values,
+                         self.doc.sections[sec_name].properties[prop_name].values)
         self.assertEqual(self.doc, jdoc)
 
         # Test correct xml save and load.
         odml.save(self.doc, self.xml_file)
         xdoc = odml.load(self.xml_file)
 
-        self.assertEqual(xdoc.sections[0].properties[0].dtype, val_type)
-        self.assertEqual(xdoc.sections[0].properties[0].values, [val_odml])
+        self.assertEqual(xdoc.sections[sec_name].properties[prop_name].dtype, val_type)
+        self.assertEqual(xdoc.sections[sec_name].properties[prop_name].values, val_odml)
+        self.assertEqual(xdoc.sections[sec_name].properties[prop_name].values,
+                         self.doc.sections[sec_name].properties[prop_name].values)
         self.assertEqual(self.doc, xdoc)
 
         # Test correct yaml save and load.
         odml.save(self.doc, self.yaml_file, "YAML")
         ydoc = odml.load(self.yaml_file, "YAML")
 
-        self.assertEqual(ydoc.sections[0].properties[0].dtype, val_type)
-        self.assertEqual(ydoc.sections[0].properties[0].values, [val_odml])
+        self.assertEqual(ydoc.sections[sec_name].properties[prop_name].dtype, val_type)
+        self.assertEqual(ydoc.sections[sec_name].properties[prop_name].values, val_odml)
+        self.assertEqual(ydoc.sections[sec_name].properties[prop_name].values,
+                         self.doc.sections[sec_name].properties[prop_name].values)
+        self.assertEqual(self.doc, ydoc)
+
+        # test multiple tuple values
+        val_type = "3-tuple"
+        val_in = ["(1; 1; 1)", "(2; 2; 2)", "(3; 3; 3)"]
+        val_odml = [["1", "1", "1"], ["2", "2", "2"], ["3", "3", "3"]]
+
+        parent_sec = self.doc.sections[0]
+        sec_name = parent_sec.name
+        prop_name = "tuple_test_multiple"
+        _ = odml.Property(name=prop_name, dtype=val_type,
+                          values=val_in, parent=parent_sec)
+
+        # Test correct json save and load.
+        odml.save(self.doc, self.json_file, "JSON")
+        jdoc = odml.load(self.json_file, "JSON")
+
+        self.assertEqual(jdoc.sections[sec_name].properties[prop_name].dtype, val_type)
+        self.assertEqual(jdoc.sections[sec_name].properties[prop_name].values, val_odml)
+        self.assertEqual(jdoc.sections[sec_name].properties[prop_name].values,
+                         self.doc.sections[sec_name].properties[prop_name].values)
+        self.assertEqual(self.doc, jdoc)
+
+        # Test correct xml save and load.
+        odml.save(self.doc, self.xml_file)
+        xdoc = odml.load(self.xml_file)
+
+        self.assertEqual(xdoc.sections[sec_name].properties[prop_name].dtype, val_type)
+        self.assertEqual(xdoc.sections[sec_name].properties[prop_name].values, val_odml)
+        self.assertEqual(xdoc.sections[sec_name].properties[prop_name].values,
+                         self.doc.sections[sec_name].properties[prop_name].values)
+        self.assertEqual(self.doc, xdoc)
+
+        # Test correct yaml save and load.
+        odml.save(self.doc, self.yaml_file, "YAML")
+        ydoc = odml.load(self.yaml_file, "YAML")
+
+        self.assertEqual(ydoc.sections[sec_name].properties[prop_name].dtype, val_type)
+        self.assertEqual(ydoc.sections[sec_name].properties[prop_name].values, val_odml)
+        self.assertEqual(ydoc.sections[sec_name].properties[prop_name].values,
+                         self.doc.sections[sec_name].properties[prop_name].values)
         self.assertEqual(self.doc, ydoc)

--- a/test/test_parser_yaml.py
+++ b/test/test_parser_yaml.py
@@ -19,7 +19,7 @@ class TestYAMLParser(unittest.TestCase):
         message = "Missing root element"
 
         with open(os.path.join(self.basepath, filename)) as raw_data:
-            parsed_doc = yaml.load(raw_data)
+            parsed_doc = yaml.safe_load(raw_data)
 
         with self.assertRaises(ParserException) as exc:
             _ = self.yaml_reader.to_odml(parsed_doc)
@@ -31,7 +31,7 @@ class TestYAMLParser(unittest.TestCase):
         message = "Could not find odml-version"
 
         with open(os.path.join(self.basepath, filename)) as raw_data:
-            parsed_doc = yaml.load(raw_data)
+            parsed_doc = yaml.safe_load(raw_data)
 
         with self.assertRaises(ParserException) as exc:
             _ = self.yaml_reader.to_odml(parsed_doc)
@@ -42,7 +42,7 @@ class TestYAMLParser(unittest.TestCase):
         filename = "invalid_version.yaml"
 
         with open(os.path.join(self.basepath, filename)) as raw_data:
-            parsed_doc = yaml.load(raw_data)
+            parsed_doc = yaml.safe_load(raw_data)
 
         with self.assertRaises(InvalidVersionException):
             _ = self.yaml_reader.to_odml(parsed_doc)

--- a/test/test_rdf_writer.py
+++ b/test/test_rdf_writer.py
@@ -134,7 +134,7 @@ class TestRDFWriter(unittest.TestCase):
     def test_section_subclass(self):
         p = os.path.join(odml.__path__[0], 'resources', 'section_subclasses.yaml')
         with open(p, "r") as f:
-            subclass = yaml.load(f)
+            subclass = yaml.safe_load(f)
 
         doc = odml.Document()
         subclass_key = next(iter(subclass))


### PR DESCRIPTION
This PR introduces a couple of fixes and updates:
- cleans up all usages of the unsafe `yaml.load` calls and replaces them with `yaml.save_load`. This also prepares for Python 3.9 compatibility.
- refactors dtype tests that are still using `assertRegexpMatches` which is supported in Python 2 but not in Python 3.9 and adds `assertRegex` instead which is supported in Python 3.2+ but not in Python 2.
- adds a `warning` module deprecation warning if the odml library is used with a Python version < 3.6.
- refactors odml style tuple handling and closes #250,  #353 and #354. Now lists of odml style tuples are properly saved to file and can be loaded again. If an invalid format is used to add an odml style tuple, more detailed exception messages are available. Also adds more odml style tuples tests.
