### PR TITLE
RDF Reader Test and Namespace

### DIFF
--- a/odml/rdf/query_creator.py
+++ b/odml/rdf/query_creator.py
@@ -8,12 +8,15 @@ provided odml query dictionaries.
 import re
 from abc import ABCMeta, abstractmethod
 
-from rdflib import Namespace, RDF
+from rdflib import RDF
 from rdflib.plugins.sparql import prepareQuery
 
 from ..format import Document
 from ..format import Property
 from ..format import Section
+from ..format import Format
+
+odmlns = Format.namespace()
 
 
 class BaseQueryCreator:
@@ -271,7 +274,7 @@ class QueryCreator(BaseQueryCreator):
             self.q_dict = q_parser.parse_query_string(q_str)
         self._prepare_query()
 
-        use_ns = {"odml": Namespace("https://g-node.org/odml-rdf#"), "rdf": RDF}
+        use_ns = {"odml": odmlns, "rdf": RDF}
         return prepareQuery(self.query, initNs=use_ns)
 
     def _prepare_query(self):

--- a/test/test_rdf_reader.py
+++ b/test/test_rdf_reader.py
@@ -1,0 +1,22 @@
+import datetime
+import unittest
+
+from rdflib import Literal
+import odml.format as format
+
+from odml import Property, Section, Document
+from odml.tools.rdf_converter import RDFWriter, RDFReader
+from odml.tools.parser_utils import ParserException
+
+odmlns = format.Format.namespace()
+
+
+class TestRDFReader(unittest.TestCase):
+
+    def setUp(self):
+        doc = Document()
+        sec = Section(name="sec1", type="test", parent=doc)
+        Section(name="sec2", type="test", parent=sec)
+        Property(name="prop1", values=[1.3], parent=sec)
+
+        self.doc = doc

--- a/test/test_rdf_reader.py
+++ b/test/test_rdf_reader.py
@@ -105,3 +105,31 @@ class TestRDFReader(unittest.TestCase):
         self.assertEqual(prop.uncertainty, "0.8")
         self.assertEqual(prop.value_origin, "force")
         self.assertEqual(prop.reference, "Experiment 1")
+
+    def test_mandatory_attrs_section(self):
+        """
+        Test if ParserError is thrown if mandatory attributes are missing for section.
+        """
+        w = RDFWriter([self.doc])
+        w.convert_to_rdf()
+        for rdf_sec in w.graph.subjects(predicate=odmlns.hasName, object=Literal("sec1")):
+            w.graph.remove((rdf_sec, odmlns.hasName, Literal("sec1")))
+
+        new_graph = w.graph.serialize(format="turtle").decode("utf-8")
+
+        with self.assertRaises(ParserException):
+            RDFReader().from_string(new_graph, "turtle")
+
+    def test_mandatory_attrs_property(self):
+        """
+        Test if ParserError is thrown if mandatory attributes are missing for section.
+        """
+        w = RDFWriter([self.doc])
+        w.convert_to_rdf()
+        for rdf_sec in w.graph.subjects(predicate=odmlns.hasName, object=Literal("prop1")):
+            w.graph.remove((rdf_sec, odmlns.hasName, Literal("prop1")))
+
+        new_graph = w.graph.serialize(format="turtle").decode("utf-8")
+
+        with self.assertRaises(ParserException):
+            RDFReader().from_string(new_graph, "turtle")

--- a/test/test_rdf_reader.py
+++ b/test/test_rdf_reader.py
@@ -42,3 +42,66 @@ class TestRDFReader(unittest.TestCase):
         self.assertEqual(len(r[0].sections), 1)
         self.assertEqual(len(r[0].sections[0].sections), 1)
         self.assertEqual(len(r[0].sections[0].properties), 1)
+
+    def test_doc(self):
+        """
+        Test if a document and its attributes get converted correctly from rdf to odml.
+        """
+        doc = Document()
+        doc.author = "D. N. Adams"
+        doc.version = 42
+        doc.date = datetime.date(1979, 10, 12)
+
+        w = RDFWriter(doc).get_rdf_str()
+        r = RDFReader().from_string(w, "turtle")
+
+        self.assertEqual(r[0].author, "D. N. Adams")
+        self.assertEqual(r[0].version, "42")
+        self.assertEqual(r[0].date, datetime.date(1979, 10, 12))
+
+    def test_section(self):
+        """
+        Test if a section and its attributes get converted correctly from rdf to odml.
+        """
+        doc = Document()
+        sec1 = Section(name="sec1", type="test", parent=doc, definition="Interesting stuff.",
+                       reference="The Journal")
+        Section(name="sec2", type="test", parent=sec1)
+
+        w = RDFWriter(doc).get_rdf_str()
+        r = RDFReader().from_string(w, "turtle")
+
+        self.assertEqual(r[0].sections[0].name, "sec1")
+        self.assertEqual(r[0].sections[0].type, "test")
+        self.assertEqual(r[0].sections[0].id, sec1.id)
+        self.assertEqual(r[0].sections[0].definition, "Interesting stuff.")
+        self.assertEqual(r[0].sections[0].reference, "The Journal")
+        self.assertEqual(r[0].sections[0].parent, r[0])
+        self.assertEqual(len(r[0].sections[0].sections), 1)
+
+    def test_property(self):
+        """
+        Test if a property and its attributes get converted correctly from rdf to odml.
+        """
+        doc = Document()
+        sec1 = Section(name="sec1", type="test", parent=doc)
+        prop2 = Property(name="numbers", definition="any number", dtype="float", parent=sec1,
+                         values=[1, 3.4, 67.8, -12], unit="meter", uncertainty=0.8,
+                         value_origin="force", reference="Experiment 1")
+
+        w = RDFWriter(doc).get_rdf_str()
+        r = RDFReader().from_string(w, "turtle")
+
+        prop = r[0].sections[0].properties["numbers"]
+
+        self.assertEqual(prop.name, "numbers")
+        self.assertEqual(prop.dtype, "float")
+        self.assertEqual(prop.id, prop2.id)
+        self.assertEqual(prop.parent, r[0].sections[0])
+        self.assertEqual(len(prop.values), 4)
+        self.assertEqual(prop.values, [1, 3.4, 67.8, -12])
+        self.assertEqual(prop.definition, "any number")
+        self.assertEqual(prop.unit, "meter")
+        self.assertEqual(prop.uncertainty, "0.8")
+        self.assertEqual(prop.value_origin, "force")
+        self.assertEqual(prop.reference, "Experiment 1")

--- a/test/test_rdf_reader.py
+++ b/test/test_rdf_reader.py
@@ -20,3 +20,25 @@ class TestRDFReader(unittest.TestCase):
         Property(name="prop1", values=[1.3], parent=sec)
 
         self.doc = doc
+
+    def test_rdf_formats(self):
+        """
+        Test if document gets correctly converted to odml for turtle, xml and n3.
+        """
+        w = RDFWriter(self.doc).get_rdf_str()
+        r = RDFReader().from_string(w, "turtle")
+        self.assertEqual(len(r[0].sections), 1)
+        self.assertEqual(len(r[0].sections[0].sections), 1)
+        self.assertEqual(len(r[0].sections[0].properties), 1)
+
+        w = RDFWriter(self.doc).get_rdf_str("xml")
+        r = RDFReader().from_string(w, "xml")
+        self.assertEqual(len(r[0].sections), 1)
+        self.assertEqual(len(r[0].sections[0].sections), 1)
+        self.assertEqual(len(r[0].sections[0].properties), 1)
+
+        w = RDFWriter(self.doc).get_rdf_str("n3")
+        r = RDFReader().from_string(w, "n3")
+        self.assertEqual(len(r[0].sections), 1)
+        self.assertEqual(len(r[0].sections[0].sections), 1)
+        self.assertEqual(len(r[0].sections[0].properties), 1)


### PR DESCRIPTION
This PR
- adds a test for the RDF Reader. Closes #211 
- adds odML namespace definition import from formats for the files in odml/rdf. Closes #345 