### PR TITLE
Change in Section type default behavior

### DIFF
--- a/odml/base.py
+++ b/odml/base.py
@@ -654,14 +654,19 @@ class Sectionable(BaseObject):
         """
         return self._repository
 
-    def create_section(self, name, type="undefined", oid=None):
+    def create_section(self, name, type="n.s.", oid=None):
         """
         Creates a new subsection that is a child of this section.
 
-        :param name: The name of the section to create.
-        :param type: The type of the section.
+        :param name: The name of the section to create. If the name is not
+                 provided, the uuid of the Property is assigned as its name.
+                 Section name is a required attribute.
+        :param type: String providing a grouping description for similar Sections.
+                     Section type is a required attribute and will be set to the string
+                     'n.s.' by default.
         :param oid: object id, UUID string as specified in RFC 4122. If no id
                     is provided, an id will be generated and assigned.
+
         :return: The new section.
         """
         from odml.section import BaseSection

--- a/odml/base.py
+++ b/odml/base.py
@@ -654,7 +654,8 @@ class Sectionable(BaseObject):
         """
         return self._repository
 
-    def create_section(self, name, type="n.s.", oid=None):
+    def create_section(self, name=None, type="n.s.", oid=None, definition=None,
+                       reference=None, repository=None, link=None, include=None):
         """
         Creates a new subsection that is a child of this section.
 
@@ -666,11 +667,18 @@ class Sectionable(BaseObject):
                      'n.s.' by default.
         :param oid: object id, UUID string as specified in RFC 4122. If no id
                     is provided, an id will be generated and assigned.
+        :param definition: String describing the definition of the Section.
+        :param reference: A reference (e.g. an URL) to an external definition
+                          of the Section.
+        :param repository: URL to a repository where this Section can be found.
+        :param link: Specifies a soft link, i.e. a path within the document.
+        :param include: Specifies an arbitrary URL. Can only be used if *link* is not set.
 
         :return: The new section.
         """
         from odml.section import BaseSection
-        sec = BaseSection(name=name, type=type, oid=oid)
+        sec = BaseSection(name=name, type=type, definition=definition, reference=reference,
+                          repository=repository, link=link, include=include, oid=oid)
         sec.parent = self
 
         return sec

--- a/odml/base.py
+++ b/odml/base.py
@@ -660,17 +660,17 @@ class Sectionable(BaseObject):
         Creates a new subsection that is a child of this section.
 
         :param name: The name of the section to create. If the name is not
-                 provided, the uuid of the Property is assigned as its name.
-                 Section name is a required attribute.
+                     provided, the object id of the Section is assigned as its name.
+                     Section name is a required attribute.
         :param type: String providing a grouping description for similar Sections.
                      Section type is a required attribute and will be set to the string
                      'n.s.' by default.
         :param oid: object id, UUID string as specified in RFC 4122. If no id
                     is provided, an id will be generated and assigned.
-        :param definition: String describing the definition of the Section.
+        :param definition: String defining this Section.
         :param reference: A reference (e.g. an URL) to an external definition
                           of the Section.
-        :param repository: URL to a repository where this Section can be found.
+        :param repository: URL to a repository in which the Section is defined.
         :param link: Specifies a soft link, i.e. a path within the document.
         :param include: Specifies an arbitrary URL. Can only be used if *link* is not set.
 

--- a/odml/property.py
+++ b/odml/property.py
@@ -140,7 +140,9 @@ class BaseProperty(base.BaseObject):
 
         for err in validation.Validation(self).errors:
             if err.is_error:
-                msg = "\n\t- %s %s: %s" % (err.obj, err.rank, err.msg)
+                use_name = err.obj.name if err.obj.id != err.obj.name else None
+                prop_formatted = "Property[id=%s|%s]" % (err.obj.id, use_name)
+                msg = "%s\n    Validation[%s]: %s" % (prop_formatted, err.rank, err.msg)
                 print(msg)
 
     def __len__(self):

--- a/odml/section.py
+++ b/odml/section.py
@@ -84,7 +84,9 @@ class BaseSection(base.Sectionable):
 
         for err in validation.Validation(self).errors:
             if err.is_error:
-                msg = "\n\t- %s %s: %s" % (err.obj, err.rank, err.msg)
+                use_name = err.obj.name if err.obj.id != err.obj.name else None
+                sec_formatted = "Section[id=%s|%s/%s]" % (err.obj.id, use_name, err.obj.type)
+                msg = "%s\n    Validation[%s]: %s" % (sec_formatted, err.rank, err.msg)
                 print(msg)
 
     def __repr__(self):

--- a/odml/section.py
+++ b/odml/section.py
@@ -27,7 +27,10 @@ class BaseSection(base.Sectionable):
 
     :param name: string providing the name of the Section. If the name is not
                  provided, the uuid of the Property is assigned as its name.
+                 Section name is a required attribute.
     :param type: String providing a grouping description for similar Sections.
+                 Section type is a required attribute and will be set to the string
+                 'n.s.' by default.
     :param parent: the parent object of the new Section. If the object is not
                    an odml.Section or an odml.Document, a ValueError is raised.
     :param definition: String describing the definition of the Section.
@@ -49,7 +52,7 @@ class BaseSection(base.Sectionable):
 
     _format = fmt.Section
 
-    def __init__(self, name=None, type=None, parent=None,
+    def __init__(self, name=None, type="n.s.", parent=None,
                  definition=None, reference=None,
                  repository=None, link=None, include=None, oid=None):
 

--- a/odml/section.py
+++ b/odml/section.py
@@ -26,17 +26,17 @@ class BaseSection(base.Sectionable):
     An odML Section.
 
     :param name: string providing the name of the Section. If the name is not
-                 provided, the uuid of the Property is assigned as its name.
+                 provided, the object id of the Section is assigned as its name.
                  Section name is a required attribute.
     :param type: String providing a grouping description for similar Sections.
                  Section type is a required attribute and will be set to the string
                  'n.s.' by default.
     :param parent: the parent object of the new Section. If the object is not
                    an odml.Section or an odml.Document, a ValueError is raised.
-    :param definition: String describing the definition of the Section.
+    :param definition: String defining this Section.
     :param reference: A reference (e.g. an URL) to an external definition
                       of the Section.
-    :param repository: URL to a repository where this Section can be found.
+    :param repository: URL to a repository in which the Section is defined.
     :param link: Specifies a soft link, i.e. a path within the document.
     :param include: Specifies an arbitrary URL. Can only be used if *link* is not set.
     :param oid: object id, UUID string as specified in RFC 4122. If no id is provided,

--- a/odml/validation.py
+++ b/odml/validation.py
@@ -133,13 +133,12 @@ def object_required_attributes(obj):
     args = obj.format().arguments
     for arg in args:
         if arg[1] == 1:
+            msg = "Missing required attribute '%s'" % (arg[0])
             if not hasattr(obj, arg[0]):
-                msg = "Missing attribute %s for %s" % (arg[0], obj.format().name.capitalize())
                 yield ValidationError(obj, msg, LABEL_ERROR)
                 continue
             obj_arg = getattr(obj, arg[0])
             if not obj_arg and not isinstance(obj_arg, bool):
-                msg = "%s %s undefined" % (obj.format().name.capitalize(), arg[0])
                 yield ValidationError(obj, msg, LABEL_ERROR)
 
 
@@ -150,12 +149,12 @@ Validation.register_handler('property', object_required_attributes)
 
 def section_type_must_be_defined(sec):
     """
-    Tests that no Section has an undefined type.
+    Tests that no Section has an unspecified type and adds a warning otherwise.
 
     :param sec: odml.Section.
     """
-    if sec.type is None or sec.type == '' or sec.type == 'undefined':
-        yield ValidationError(sec, 'Section type undefined', LABEL_WARNING)
+    if sec.type and sec.type == "n.s.":
+        yield ValidationError(sec, "Section type not specified", LABEL_WARNING)
 
 
 Validation.register_handler('section', section_type_must_be_defined)

--- a/test/test_doc.py
+++ b/test/test_doc.py
@@ -312,7 +312,7 @@ class TestSection(unittest.TestCase):
         self.assertEqual(len(root.sections), 2)
         self.assertEqual(subsec.parent, root)
         self.assertEqual(root.sections[name], subsec)
-        self.assertEqual(root.sections[name].type, "undefined")
+        self.assertEqual(root.sections[name].type, "n.s.")
 
         name = "subsubsec"
         subsec = root.sections[0].create_section(name)

--- a/test/test_section.py
+++ b/test/test_section.py
@@ -906,7 +906,7 @@ class TestSection(unittest.TestCase):
         self.assertEqual(len(root.sections), 2)
         self.assertEqual(subsec.parent, root)
         self.assertEqual(root.sections[name], subsec)
-        self.assertEqual(root.sections[name].type, "undefined")
+        self.assertEqual(root.sections[name].type, "n.s.")
 
         name = "subsubsec"
         subsec = root.sections[0].create_section(name)

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -84,12 +84,6 @@ class TestValidation(unittest.TestCase):
                 self.assertFalse(err.is_error)
                 self.assertIn(test_msg, err.msg)
 
-    def test_section_type(self):
-        doc = samplefile.parse("""s1[undefined]""")
-        res = validate(doc)
-        # the section type is undefined (also in the mapping)
-        self.assertError(res, "Section type undefined")
-
     def test_section_in_terminology(self):
         doc = samplefile.parse("""s1[T1]""")
         res = validate(doc)
@@ -202,17 +196,12 @@ class TestValidation(unittest.TestCase):
     def test_standalone_section(self):
         """
         Test if standalone section does not return errors if required attributes are correct.
-        If type is undefined, check error message.
+        If type is not specified, check error message.
         """
 
         sec_one = odml.Section("sec1")
-
         res = validate(sec_one)
-        self.assertError(res, "Section type undefined")
-
-        doc = samplefile.parse("""s1[undefined]""")
-        res = validate(doc)
-        self.assertError(res, "Section type undefined")
+        self.assertError(res, "Section type not specified")
 
     def test_standalone_property(self):
         """
@@ -229,14 +218,15 @@ class TestValidation(unittest.TestCase):
         """
         Test validation errors printed to stdout on section init.
         """
-        val_errs = StringIO()
+        check_msg = "Missing required attribute 'type'"
 
+        val_errs = StringIO()
         old_stdout = sys.stdout
         sys.stdout = val_errs
         odml.Section(name="sec", type=None)
         sys.stdout = old_stdout
 
-        self.assertIn("Section type undefined", val_errs.getvalue())
+        self.assertIn(check_msg, val_errs.getvalue())
 
     def test_prop_string_values(self):
         """
@@ -246,7 +236,7 @@ class TestValidation(unittest.TestCase):
 
         prop0 = odml.Property(name='words', dtype="string",
                               values=['-13', '101', '-11', 'hello'])
-        assert len(validate(prop0).errors) == 0
+        self.assertEquals(len(validate(prop0).errors), 0)
 
         msg_base = 'Dtype of property "%s" currently is "string", but might fit dtype "%s"!'
 

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -287,6 +287,19 @@ class TestValidation(unittest.TestCase):
                                       '(39.12; 56; 67.18)'])
         self.assertError(validate(prop9), msg_base % ("Coos", "3-tuple"))
 
+    def load_section_validation(self, doc):
+        filter_func = lambda x: x.msg == filter_msg and x.obj.name == filter_name
+
+        # Check error for deliberate empty section type
+        filter_msg = "Missing required attribute 'type'"
+        filter_name = "sec_type_empty"
+        self.assertGreater(len(list(filter(filter_func, validate(doc).errors))), 0)
+
+        # Check warning for not specified section type
+        filter_msg = "Section type not specified"
+        filter_name = "sec_type_undefined"
+        self.assertGreater(len(list(filter(filter_func, validate(doc).errors))), 0)
+
     def test_load_section_xml(self):
         """
         Test if loading xml document raises validation errors for Sections with undefined type.
@@ -295,12 +308,7 @@ class TestValidation(unittest.TestCase):
         path = os.path.join(self.dir_path, "resources", "validation_section.xml")
         doc = odml.load(path)
 
-        assert len(list(filter(
-            lambda x: x.msg == "Section type undefined" and x.obj.name == "sec_type_undefined",
-            validate(doc).errors))) > 0
-        assert len(list(filter(
-            lambda x: x.msg == "Section type undefined" and x.obj.name == "sec_type_empty",
-            validate(doc).errors))) > 0
+        self.load_section_validation(doc)
 
     def test_load_section_json(self):
         """
@@ -310,12 +318,7 @@ class TestValidation(unittest.TestCase):
         path = os.path.join(self.dir_path, "resources", "validation_section.json")
         doc = odml.load(path, "JSON")
 
-        assert len(list(filter(
-            lambda x: x.msg == "Section type undefined" and x.obj.name == "sec_type_undefined",
-            validate(doc).errors))) > 0
-        assert len(list(filter(
-            lambda x: x.msg == "Section type undefined" and x.obj.name == "sec_type_empty",
-            validate(doc).errors))) > 0
+        self.load_section_validation(doc)
 
     def test_load_section_yaml(self):
         """
@@ -325,12 +328,7 @@ class TestValidation(unittest.TestCase):
         path = os.path.join(self.dir_path, "resources", "validation_section.yaml")
         doc = odml.load(path, "YAML")
 
-        assert len(list(filter(
-            lambda x: x.msg == "Section type undefined" and x.obj.name == "sec_type_undefined",
-            validate(doc).errors))) > 0
-        assert len(list(filter(
-            lambda x: x.msg == "Section type undefined" and x.obj.name == "sec_type_empty",
-            validate(doc).errors))) > 0
+        self.load_section_validation(doc)
 
     def load_dtypes_validation(self, doc):
         msg_base = 'Dtype of property "%s" currently is "string", but might fit dtype "%s"!'

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -222,7 +222,8 @@ class TestValidation(unittest.TestCase):
         prop = odml.Property()
         prop.type = ""
 
-        assert len(list(filter(lambda x: x.is_error, validate(prop).errors))) == 0
+        errs = list(filter(lambda x: x.is_error, validate(prop).errors))
+        self.assertEquals(len(errs), 0)
 
     def test_section_init(self):
         """
@@ -235,7 +236,7 @@ class TestValidation(unittest.TestCase):
         odml.Section(name="sec", type=None)
         sys.stdout = old_stdout
 
-        assert "Section type undefined" in val_errs.getvalue()
+        self.assertIn("Section type undefined", val_errs.getvalue())
 
     def test_prop_string_values(self):
         """
@@ -247,51 +248,44 @@ class TestValidation(unittest.TestCase):
                               values=['-13', '101', '-11', 'hello'])
         assert len(validate(prop0).errors) == 0
 
+        msg_base = 'Dtype of property "%s" currently is "string", but might fit dtype "%s"!'
+
         prop1 = odml.Property(name='members', dtype="string",
                               values=['-13', '101', '-11', '0', '-8'])
-        self.assertError(validate(prop1), 'Dtype of property "members" currently is "string",'
-                                          ' but might fit dtype "int"!')
+        self.assertError(validate(prop1), msg_base % ("members", "int"))
 
         prop2 = odml.Property(name='potential', dtype="string",
                               values=['-4.8', '10.0', '-11.9', '-10.0', '18.0'])
-        self.assertError(validate(prop2), 'Dtype of property "potential" currently is "string", '
-                                          'but might fit dtype "float"!')
+        self.assertError(validate(prop2), msg_base % ("potential", "float"))
 
         prop3 = odml.Property(name='dates', dtype="string",
                               values=['1997-12-14', '00-12-14', '89-07-04'])
-        self.assertError(validate(prop3), 'Dtype of property "dates" currently is "string", '
-                                          'but might fit dtype "date"!')
+        self.assertError(validate(prop3), msg_base % ("dates", "date"))
 
         prop4 = odml.Property(name='datetimes', dtype="string",
                               values=['97-12-14 11:11:11', '97-12-14 12:12', '1997-12-14 03:03'])
-        self.assertError(validate(prop4), 'Dtype of property "datetimes" currently is "string", '
-                                          'but might fit dtype "datetime"!')
+        self.assertError(validate(prop4), msg_base % ("datetimes", "datetime"))
 
         prop5 = odml.Property(name='times', dtype="string",
                               values=['11:11:11', '12:12:12', '03:03:03'])
-        self.assertError(validate(prop5), 'Dtype of property "times" currently is "string", '
-                                          'but might fit dtype "time"!')
+        self.assertError(validate(prop5), msg_base % ("times", "time"))
 
         prop6 = odml.Property(name='sent', dtype="string",
                               values=['False', True, 'TRUE', False, 't'])
-        self.assertError(validate(prop6), 'Dtype of property "sent" currently is "string", '
-                                          'but might fit dtype "boolean"!')
+        self.assertError(validate(prop6), msg_base % ("sent", "boolean"))
 
         prop7 = odml.Property(name='texts', dtype="string",
                               values=['line1\n line2', 'line3\n line4', '\nline5\nline6'])
-        self.assertError(validate(prop7), 'Dtype of property "texts" currently is "string", '
-                                          'but might fit dtype "text"!')
+        self.assertError(validate(prop7), msg_base % ("texts", "text"))
 
         prop8 = odml.Property(name="Location", dtype='string',
                               values=['(39.12; 67.19)', '(39.12; 67.19)', '(39.12; 67.18)'])
-        self.assertError(validate(prop8), 'Dtype of property "Location" currently is "string", '
-                                          'but might fit dtype "2-tuple"!')
+        self.assertError(validate(prop8), msg_base % ("Location", "2-tuple"))
 
         prop9 = odml.Property(name="Coos", dtype='string',
                               values=['(39.12; 89; 67.19)', '(39.12; 78; 67.19)',
                                       '(39.12; 56; 67.18)'])
-        self.assertError(validate(prop9), 'Dtype of property "Coos" currently is "string", '
-                                          'but might fit dtype "3-tuple"!')
+        self.assertError(validate(prop9), msg_base % ("Coos", "3-tuple"))
 
     def test_load_section_xml(self):
         """
@@ -308,65 +302,6 @@ class TestValidation(unittest.TestCase):
             lambda x: x.msg == "Section type undefined" and x.obj.name == "sec_type_empty",
             validate(doc).errors))) > 0
 
-    def test_load_dtypes_xml(self):
-        """
-        Test if loading xml document raises validation errors for Properties with undefined dtypes.
-        """
-
-        path = os.path.join(self.dir_path, "resources", "validation_dtypes.xml")
-        doc = odml.load(path)
-
-        self.assertError(validate(doc), 'Dtype of property "members_no" currently is "string", '
-                                        'but might fit dtype "int"!')
-
-        self.assertError(validate(doc), 'Dtype of property "potential_no" currently is "string", '
-                                        'but might fit dtype "float"!')
-
-        self.assertError(validate(doc), 'Dtype of property "dates_no" currently is "string", '
-                                        'but might fit dtype "date"!')
-
-        self.assertError(validate(doc), 'Dtype of property "datetimes_no" currently is "string", '
-                                        'but might fit dtype "datetime"!')
-
-        self.assertError(validate(doc), 'Dtype of property "times_no" currently is "string", '
-                                        'but might fit dtype "time"!')
-
-        self.assertError(validate(doc), 'Dtype of property "sent_no" currently is "string", '
-                                        'but might fit dtype "boolean"!')
-
-        self.assertError(validate(doc), 'Dtype of property "Location_no" currently is "string", '
-                                        'but might fit dtype "2-tuple"!')
-
-        self.assertError(validate(doc), 'Dtype of property "Coos_no" currently is "string", '
-                                        'but might fit dtype "3-tuple"!')
-
-        self.assertError(validate(doc), 'Dtype of property "members_mislabelled" currently is '
-                                        '"string", but might fit dtype "int"!')
-
-        self.assertError(validate(doc), 'Dtype of property "potential_mislabelled" currently is '
-                                        '"string", but might fit dtype "float"!')
-
-        self.assertError(validate(doc), 'Dtype of property "dates_mislabelled" currently is '
-                                        '"string", but might fit dtype "date"!')
-
-        self.assertError(validate(doc), 'Dtype of property "datetimes_mislabelled" currently is '
-                                        '"string", but might fit dtype "datetime"!')
-
-        self.assertError(validate(doc), 'Dtype of property "times_mislabelled" currently is '
-                                        '"string", but might fit dtype "time"!')
-
-        self.assertError(validate(doc), 'Dtype of property "sent_mislabelled" currently is '
-                                        '"string", but might fit dtype "boolean"!')
-
-        self.assertError(validate(doc), 'Dtype of property "texts_mislabelled" currently is '
-                                        '"string", but might fit dtype "text"!')
-
-        self.assertError(validate(doc), 'Dtype of property "Location_mislabelled" currently is '
-                                        '"string", but might fit dtype "2-tuple"!')
-
-        self.assertError(validate(doc), 'Dtype of property "Coos_mislabelled" currently is '
-                                        '"string", but might fit dtype "3-tuple"!')
-
     def test_load_section_json(self):
         """
         Test if loading json document raises validation errors for Sections with undefined type.
@@ -381,65 +316,6 @@ class TestValidation(unittest.TestCase):
         assert len(list(filter(
             lambda x: x.msg == "Section type undefined" and x.obj.name == "sec_type_empty",
             validate(doc).errors))) > 0
-
-    def test_load_dtypes_json(self):
-        """
-        Test if loading json document raises validation errors for Properties with undefined dtypes.
-        """
-
-        path = os.path.join(self.dir_path, "resources", "validation_dtypes.json")
-        doc = odml.load(path, "JSON")
-
-        self.assertError(validate(doc), 'Dtype of property "members_no" currently is "string", '
-                                        'but might fit dtype "int"!')
-
-        self.assertError(validate(doc), 'Dtype of property "potential_no" currently is "string", '
-                                        'but might fit dtype "float"!')
-
-        self.assertError(validate(doc), 'Dtype of property "dates_no" currently is "string", '
-                                        'but might fit dtype "date"!')
-
-        self.assertError(validate(doc), 'Dtype of property "datetimes_no" currently is "string", '
-                                        'but might fit dtype "datetime"!')
-
-        self.assertError(validate(doc), 'Dtype of property "times_no" currently is "string", '
-                                        'but might fit dtype "time"!')
-
-        self.assertError(validate(doc), 'Dtype of property "sent_no" currently is "string", '
-                                        'but might fit dtype "boolean"!')
-
-        self.assertError(validate(doc), 'Dtype of property "Location_no" currently is "string", '
-                                        'but might fit dtype "2-tuple"!')
-
-        self.assertError(validate(doc), 'Dtype of property "Coos_no" currently is "string", '
-                                        'but might fit dtype "3-tuple"!')
-
-        self.assertError(validate(doc), 'Dtype of property "members_mislabelled" currently is '
-                                        '"string", but might fit dtype "int"!')
-
-        self.assertError(validate(doc), 'Dtype of property "potential_mislabelled" currently is '
-                                        '"string", but might fit dtype "float"!')
-
-        self.assertError(validate(doc), 'Dtype of property "dates_mislabelled" currently is '
-                                        '"string", but might fit dtype "date"!')
-
-        self.assertError(validate(doc), 'Dtype of property "datetimes_mislabelled" currently is '
-                                        '"string", but might fit dtype "datetime"!')
-
-        self.assertError(validate(doc), 'Dtype of property "times_mislabelled" currently is '
-                                        '"string", but might fit dtype "time"!')
-
-        self.assertError(validate(doc), 'Dtype of property "sent_mislabelled" currently is '
-                                        '"string", but might fit dtype "boolean"!')
-
-        self.assertError(validate(doc), 'Dtype of property "texts_mislabelled" currently is '
-                                        '"string", but might fit dtype "text"!')
-
-        self.assertError(validate(doc), 'Dtype of property "Location_mislabelled" currently is '
-                                        '"string", but might fit dtype "2-tuple"!')
-
-        self.assertError(validate(doc), 'Dtype of property "Coos_mislabelled" currently is '
-                                        '"string", but might fit dtype "3-tuple"!')
 
     def test_load_section_yaml(self):
         """
@@ -456,61 +332,55 @@ class TestValidation(unittest.TestCase):
             lambda x: x.msg == "Section type undefined" and x.obj.name == "sec_type_empty",
             validate(doc).errors))) > 0
 
+    def load_dtypes_validation(self, doc):
+        msg_base = 'Dtype of property "%s" currently is "string", but might fit dtype "%s"!'
+
+        doc_val = validate(doc)
+        self.assertError(doc_val, msg_base % ("members_no", "int"))
+        self.assertError(doc_val, msg_base % ("potential_no", "float"))
+        self.assertError(doc_val, msg_base % ("dates_no", "date"))
+        self.assertError(doc_val, msg_base % ("datetimes_no", "datetime"))
+        self.assertError(doc_val, msg_base % ("times_no", "time"))
+        self.assertError(doc_val, msg_base % ("sent_no", "boolean"))
+        self.assertError(doc_val, msg_base % ("Location_no", "2-tuple"))
+        self.assertError(doc_val, msg_base % ("Coos_no", "3-tuple"))
+
+        self.assertError(doc_val, msg_base % ("members_mislabelled", "int"))
+        self.assertError(doc_val, msg_base % ("potential_mislabelled", "float"))
+        self.assertError(doc_val, msg_base % ("dates_mislabelled", "date"))
+        self.assertError(doc_val, msg_base % ("datetimes_mislabelled", "datetime"))
+        self.assertError(doc_val, msg_base % ("times_mislabelled", "time"))
+        self.assertError(doc_val, msg_base % ("sent_mislabelled", "boolean"))
+        self.assertError(doc_val, msg_base % ("texts_mislabelled", "text"))
+        self.assertError(doc_val, msg_base % ("Location_mislabelled", "2-tuple"))
+        self.assertError(doc_val, msg_base % ("Coos_mislabelled", "3-tuple"))
+
+    def test_load_dtypes_xml(self):
+        """
+        Test if loading xml document raises validation errors
+        for Properties with undefined dtypes.
+        """
+
+        path = os.path.join(self.dir_path, "resources", "validation_dtypes.xml")
+        doc = odml.load(path)
+        self.load_dtypes_validation(doc)
+
+    def test_load_dtypes_json(self):
+        """
+        Test if loading json document raises validation errors
+        for Properties with undefined dtypes.
+        """
+
+        path = os.path.join(self.dir_path, "resources", "validation_dtypes.json")
+        doc = odml.load(path, "JSON")
+        self.load_dtypes_validation(doc)
+
     def test_load_dtypes_yaml(self):
         """
-        Test if loading yaml document raises validation errors for Properties with undefined dtypes.
+        Test if loading yaml document raises validation errors
+        for Properties with undefined dtypes.
         """
 
         path = os.path.join(self.dir_path, "resources", "validation_dtypes.yaml")
         doc = odml.load(path, "YAML")
-
-        self.assertError(validate(doc), 'Dtype of property "members_no" currently is "string", '
-                                        'but might fit dtype "int"!')
-
-        self.assertError(validate(doc), 'Dtype of property "potential_no" currently is "string", '
-                                        'but might fit dtype "float"!')
-
-        self.assertError(validate(doc), 'Dtype of property "dates_no" currently is "string", '
-                                        'but might fit dtype "date"!')
-
-        self.assertError(validate(doc), 'Dtype of property "datetimes_no" currently is "string", '
-                                        'but might fit dtype "datetime"!')
-
-        self.assertError(validate(doc), 'Dtype of property "times_no" currently is "string", '
-                                        'but might fit dtype "time"!')
-
-        self.assertError(validate(doc), 'Dtype of property "sent_no" currently is "string", '
-                                        'but might fit dtype "boolean"!')
-
-        self.assertError(validate(doc), 'Dtype of property "Location_no" currently is "string", '
-                                        'but might fit dtype "2-tuple"!')
-
-        self.assertError(validate(doc), 'Dtype of property "Coos_no" currently is "string", '
-                                        'but might fit dtype "3-tuple"!')
-
-        self.assertError(validate(doc), 'Dtype of property "members_mislabelled" currently is '
-                                        '"string", but might fit dtype "int"!')
-
-        self.assertError(validate(doc), 'Dtype of property "potential_mislabelled" currently is '
-                                        '"string", but might fit dtype "float"!')
-
-        self.assertError(validate(doc), 'Dtype of property "dates_mislabelled" currently is '
-                                        '"string", but might fit dtype "date"!')
-
-        self.assertError(validate(doc), 'Dtype of property "datetimes_mislabelled" currently is '
-                                        '"string", but might fit dtype "datetime"!')
-
-        self.assertError(validate(doc), 'Dtype of property "times_mislabelled" currently is '
-                                        '"string", but might fit dtype "time"!')
-
-        self.assertError(validate(doc), 'Dtype of property "sent_mislabelled" currently is '
-                                        '"string", but might fit dtype "boolean"!')
-
-        self.assertError(validate(doc), 'Dtype of property "texts_mislabelled" currently is '
-                                        '"string", but might fit dtype "text"!')
-
-        self.assertError(validate(doc), 'Dtype of property "Location_mislabelled" currently is '
-                                        '"string", but might fit dtype "2-tuple"!')
-
-        self.assertError(validate(doc), 'Dtype of property "Coos_mislabelled" currently is '
-                                        '"string", but might fit dtype "3-tuple"!')
+        self.load_dtypes_validation(doc)


### PR DESCRIPTION
With recent updates the library now respects and enforces `Section.type` as a required attribute and allows save only with documents where this requirement is satisfied.
To allow backwards file compatibility and ease usage, `Section.type` is by default set to the string `n.s.` (not specified), which means files where no section type had been specified can be loaded and saved, but will contain `n.s.` as value for all `Sections.types` that where previously not specified.
Further the validation run before a document can be saved will issue a warning, if a `Section.type` with value `n.s.` is encountered and will still refuse to save with an error, if an empty `Section.type` is encountered.

Further changes in this PR:
- the `base.Sectionable.create_section` method has been updated to conform with `Section.__init__`. This should close issue #368 
- Validation messages to increase clarity for the user
- Tests corresponding to the `Section.type` and validations in general have been updated to adhere to and reflect the changes and refactored to reduce redundancy in general.