### PR TITLE
Adding Section properties cardinality

### DIFF
--- a/odml/format.py
+++ b/odml/format.py
@@ -156,7 +156,8 @@ class Section(Format):
         'repository': 0,
         'section': 0,
         'include': 0,
-        'property': 0
+        'property': 0,
+        'prop_cardinality': 0
     }
     _map = {
         'section': 'sections',

--- a/odml/section.py
+++ b/odml/section.py
@@ -388,6 +388,9 @@ class BaseSection(base.Sectionable):
         """
         self._prop_cardinality = format_cardinality(new_value)
 
+        # Validate and inform user if the current cardinality is violated
+        self._properties_cardinality_validation()
+
     def set_properties_cardinality(self, min_val=None, max_val=None):
         """
         Sets the Properties cardinality of a Section.
@@ -398,6 +401,17 @@ class BaseSection(base.Sectionable):
                         no restrictions on values elements maximum. Default is None.
         """
         self.prop_cardinality = (min_val, max_val)
+
+    def _properties_cardinality_validation(self):
+        """
+        Runs a validation to check whether the properties cardinality
+        is respected and prints a warning message otherwise.
+        """
+        valid = validation.Validation(self)
+        # Make sure to display only warnings of the current section
+        res = [curr for curr in valid.errors if self.id == curr.obj.id]
+        for err in res:
+            print("%s: %s" % (err.rank.capitalize(), err.msg))
 
     @inherit_docstring
     def get_terminology_equivalent(self):

--- a/odml/section.py
+++ b/odml/section.py
@@ -18,6 +18,7 @@ from .doc import BaseDocument
 from .property import BaseProperty
 # it MUST however not be used to create any Property objects
 from .tools.doc_inherit import inherit_docstring, allow_inherit_docstring
+from .util import format_cardinality
 
 
 @allow_inherit_docstring
@@ -85,11 +86,15 @@ class BaseSection(base.Sectionable):
         self._repository = repository
         self._link = link
         self._include = include
-        self._prop_cardinality = prop_cardinality
+        self._prop_cardinality = None
 
         # this may fire a change event, so have the section setup then
         self.type = type
         self.parent = parent
+
+        # This might lead to a validation warning, since properties are set
+        # at a later point in time.
+        self.prop_cardinality = prop_cardinality
 
         for err in validation.Validation(self).errors:
             if err.is_error:
@@ -354,6 +359,45 @@ class BaseSection(base.Sectionable):
     @base.Sectionable.repository.setter
     def repository(self, url):
         base.Sectionable.repository.fset(self, url)
+
+    @property
+    def prop_cardinality(self):
+        """
+        The Property cardinality of a Section. It defines how many Properties
+        are minimally required and how many Properties should be maximally
+        stored. Use the 'set_properties_cardinality' method to set.
+        """
+        return self._prop_cardinality
+
+    @prop_cardinality.setter
+    def prop_cardinality(self, new_value):
+        """
+        Sets the Properties cardinality of a Section.
+
+        The following cardinality cases are supported:
+        (n, n) - default, no restriction
+        (d, n) - minimally d entries, no maximum
+        (n, d) - maximally d entries, no minimum
+        (d, d) - minimally d entries, maximally d entries
+
+        Only positive integers are supported. 'None' is used to denote
+        no restrictions on a maximum or minimum.
+
+        :param new_value: Can be either 'None', a positive integer, which will set
+                          the maximum or an integer 2-tuple of the format '(min, max)'.
+        """
+        self._prop_cardinality = format_cardinality(new_value)
+
+    def set_properties_cardinality(self, min_val=None, max_val=None):
+        """
+        Sets the Properties cardinality of a Section.
+
+        :param min_val: Required minimal number of values elements. None denotes
+                        no restrictions on values elements minimum. Default is None.
+        :param max_val: Allowed maximal number of values elements. None denotes
+                        no restrictions on values elements maximum. Default is None.
+        """
+        self.prop_cardinality = (min_val, max_val)
 
     @inherit_docstring
     def get_terminology_equivalent(self):

--- a/odml/section.py
+++ b/odml/section.py
@@ -40,8 +40,12 @@ class BaseSection(base.Sectionable):
     :param link: Specifies a soft link, i.e. a path within the document.
     :param include: Specifies an arbitrary URL. Can only be used if *link* is not set.
     :param oid: object id, UUID string as specified in RFC 4122. If no id is provided,
-               an id will be generated and assigned. An id has to be unique
-               within an odML Document.
+                an id will be generated and assigned. An id has to be unique
+                within an odML Document.
+    :param prop_cardinality: Property cardinality defines how many Properties are allowed for this
+                             Section. By default unlimited Properties can be set.
+                             A required number of Properties can be set by assigning a tuple of the
+                             format "(min, max)".
     """
 
     type = None
@@ -54,7 +58,8 @@ class BaseSection(base.Sectionable):
 
     def __init__(self, name=None, type="n.s.", parent=None,
                  definition=None, reference=None,
-                 repository=None, link=None, include=None, oid=None):
+                 repository=None, link=None, include=None, oid=None,
+                 prop_cardinality=None):
 
         # Sets _sections Smartlist and _repository to None, so run first.
         super(BaseSection, self).__init__()
@@ -80,6 +85,7 @@ class BaseSection(base.Sectionable):
         self._repository = repository
         self._link = link
         self._include = include
+        self._prop_cardinality = prop_cardinality
 
         # this may fire a change event, so have the section setup then
         self.type = type

--- a/odml/validation.py
+++ b/odml/validation.py
@@ -455,6 +455,35 @@ def property_values_string_check(prop):
 Validation.register_handler('property', property_values_string_check)
 
 
+def section_properties_cardinality(obj):
+    """
+    Checks Section properties against any set property cardinality.
+
+    :param obj: odml.Section
+    :return: Yields a ValidationError warning, if a set cardinality is not met.
+    """
+    if obj.prop_cardinality and isinstance(obj.prop_cardinality, tuple):
+
+        val_min = obj.prop_cardinality[0]
+        val_max = obj.prop_cardinality[1]
+
+        val_len = len(obj.properties) if obj.properties else 0
+
+        invalid_cause = ""
+        if val_min and val_len < val_min:
+            invalid_cause = "minimum %s" % val_min
+        elif val_max and (obj.properties and len(obj.properties) > val_max):
+            invalid_cause = "maximum %s" % val_max
+
+        if invalid_cause:
+            msg = "Section properties cardinality violated"
+            msg += " (%s values, %s found)" % (invalid_cause, val_len)
+            yield ValidationError(obj, msg, LABEL_WARNING)
+
+
+Validation.register_handler("section", section_properties_cardinality)
+
+
 def property_values_cardinality(prop):
     """
     Checks Property values against any set value cardinality.

--- a/test/test_section.py
+++ b/test/test_section.py
@@ -978,6 +978,94 @@ class TestSection(unittest.TestCase):
         self.assertEqual(len(ex3['first'].sections), 1)
         self.assertEqual(len(ex3['first']['third']), 0)
 
+    def _test_cardinality_re_assignment(self, obj, obj_attribute):
+        """
+        Tests the basic set of both Section properties and sub-sections cardinality.
+
+        :param obj: odml Section
+        :param obj_attribute: string with the cardinality attribute that is supposed to be tested.
+                              Should be either 'prop_cardinality' or 'sec_cardinality'.
+        """
+        oat = obj_attribute
+
+        # Test Section prop/sec cardinality reset
+        for non_val in [None, "", [], (), {}]:
+            setattr(obj, oat, non_val)
+            self.assertIsNone(getattr(obj, oat))
+            setattr(obj, oat, 1)
+
+        # Test Section prop/sec cardinality single int max assignment
+        setattr(obj, oat, 10)
+        self.assertEqual(getattr(obj, oat), (None, 10))
+
+        # Test Section prop/sec cardinality tuple max assignment
+        setattr(obj, oat, (None, 5))
+        self.assertEqual(getattr(obj, oat), (None, 5))
+
+        # Test Section prop/sec cardinality tuple min assignment
+        setattr(obj, oat, (5, None))
+        self.assertEqual(getattr(obj, oat), (5, None))
+
+        # Test Section prop/sec cardinality min/max assignment
+        setattr(obj, oat, (1, 5))
+        self.assertEqual(getattr(obj, oat), (1, 5))
+
+        # -- Test Section prop/sec cardinality assignment failures
+        with self.assertRaises(ValueError):
+            setattr(obj, oat, "a")
+
+        with self.assertRaises(ValueError):
+            setattr(obj, oat, -1)
+
+        with self.assertRaises(ValueError):
+            setattr(obj, oat, (1, "b"))
+
+        with self.assertRaises(ValueError):
+            setattr(obj, oat, (1, 2, 3))
+
+        with self.assertRaises(ValueError):
+            setattr(obj, oat, [1, 2, 3])
+
+        with self.assertRaises(ValueError):
+            setattr(obj, oat, {1: 2, 3: 4})
+
+        with self.assertRaises(ValueError):
+            setattr(obj, oat, (-1, 1))
+
+        with self.assertRaises(ValueError):
+            setattr(obj, oat, (1, -5))
+
+        with self.assertRaises(ValueError):
+            setattr(obj, oat, (5, 1))
+
+    def test_properties_cardinality(self):
+        """
+        Tests the basic assignment rules for Section Properties cardinality
+        on init and re-assignment but does not test properties assignment or
+        the actual cardinality validation.
+        """
+        doc = Document()
+
+        # -- Test set cardinality on Section init
+        # Test empty init
+        sec_prop_card_none = Section(name="sec_prop_card_none", type="test", parent=doc)
+        self.assertIsNone(sec_prop_card_none.prop_cardinality)
+
+        # Test single int max init
+        sec_card_max = Section(name="prop_cardinality_max", prop_cardinality=10, parent=doc)
+        self.assertEqual(sec_card_max.prop_cardinality, (None, 10))
+
+        # Test tuple init
+        sec_card_min = Section(name="prop_cardinality_min", prop_cardinality=(2, None), parent=doc)
+        self.assertEqual(sec_card_min.prop_cardinality, (2, None))
+
+        # -- Test Section properties cardinality re-assignment
+        sec = Section(name="prop", prop_cardinality=(None, 10), parent=doc)
+        self.assertEqual(sec.prop_cardinality, (None, 10))
+
+        # Use general method to reduce redundancy
+        self._test_cardinality_re_assignment(sec, 'prop_cardinality')
+
     def test_link(self):
         pass
 

--- a/test/test_section.py
+++ b/test/test_section.py
@@ -1066,6 +1066,59 @@ class TestSection(unittest.TestCase):
         # Use general method to reduce redundancy
         self._test_cardinality_re_assignment(sec, 'prop_cardinality')
 
+    def _test_set_cardinality_method(self, obj, obj_attribute, set_cardinality_method):
+        """
+        Tests the basic set convenience method of both Section properties and
+        sub-sections cardinality.
+
+        :param obj: odml Section
+        :param obj_attribute: string with the cardinality attribute that is supposed to be tested.
+                              Should be either 'prop_cardinality' or 'sec_cardinality'.
+        :param set_cardinality_method: The convenience method used to set the cardinality.
+        """
+        oba = obj_attribute
+
+        # Test Section prop/sec cardinality min assignment
+        set_cardinality_method(1)
+        self.assertEqual(getattr(obj, oba), (1, None))
+
+        # Test Section prop/sec cardinality keyword min assignment
+        set_cardinality_method(min_val=2)
+        self.assertEqual(getattr(obj, oba), (2, None))
+
+        # Test Section prop/sec cardinality max assignment
+        set_cardinality_method(None, 1)
+        self.assertEqual(getattr(obj, oba), (None, 1))
+
+        # Test Section prop/sec cardinality keyword max assignment
+        set_cardinality_method(max_val=2)
+        self.assertEqual(getattr(obj, oba), (None, 2))
+
+        # Test Section prop/sec cardinality min max assignment
+        set_cardinality_method(1, 2)
+        self.assertEqual(getattr(obj, oba), (1, 2))
+
+        # Test Section prop/sec cardinality keyword min max assignment
+        set_cardinality_method(min_val=2, max_val=5)
+        self.assertEqual(getattr(obj, oba), (2, 5))
+
+        # Test Section prop/sec cardinality empty reset
+        set_cardinality_method()
+        self.assertIsNone(getattr(obj, oba))
+
+        # Test Section prop/sec cardinality keyword empty reset
+        set_cardinality_method(1)
+        self.assertIsNotNone(getattr(obj, oba))
+        set_cardinality_method(min_val=None, max_val=None)
+        self.assertIsNone(getattr(obj, oba))
+
+    def test_set_properties_cardinality(self):
+        doc = Document()
+        sec = Section(name="sec", type="test", parent=doc)
+
+        # Use general method to reduce redundancy
+        self._test_set_cardinality_method(sec, 'prop_cardinality', sec.set_properties_cardinality)
+
     def test_link(self):
         pass
 

--- a/test/test_section_integration.py
+++ b/test/test_section_integration.py
@@ -191,6 +191,72 @@ class TestSectionIntegration(unittest.TestCase):
         self.assertEqual(len(ysec_lvl_2.sections), 4)
         self.assertEqual(len(ysec_lvl_2.properties), 4)
 
+    def _test_cardinality_load(self, obj_attribute, doc, card_dict,
+                               sec_empty, sec_max, sec_min, sec_full):
+        """
+        Tests the basic set of both Section properties and sub-sections cardinality.
+
+        :param obj_attribute: string with the cardinality attribute that is supposed to be tested.
+                              Should be either 'prop_cardinality' or 'sec_cardinality'.
+        :param doc: loaded odml Document to be tested.
+        :param card_dict: dictionary containing cardinality conditions mapped to the values that
+                          should have been restored.
+        """
+        oat = obj_attribute
+
+        sec = doc.sections[sec_empty]
+        self.assertIsNone(getattr(sec, oat))
+
+        sec = doc.sections[sec_max]
+        self.assertEqual(getattr(sec, oat), card_dict[sec_max])
+
+        sec = doc.sections[sec_min]
+        self.assertEqual(getattr(sec, oat), card_dict[sec_min])
+
+        sec = doc.sections[sec_full]
+        self.assertEqual(getattr(sec, oat), card_dict[sec_full])
+
+    def test_prop_cardinality(self):
+        """
+        Test saving and loading of Section properties cardinality variants to
+        and from all supported file formats.
+        """
+        doc = odml.Document()
+        sec_empty = "card_empty"
+        sec_max = "card_max"
+        sec_min = "card_min"
+        sec_full = "card_full"
+        card_dict = {
+            sec_empty: None,
+            sec_max: (None, 10),
+            sec_min: (2, None),
+            sec_full: (1, 5)
+        }
+
+        _ = odml.Section(name=sec_empty, type="test", parent=doc)
+        _ = odml.Section(name=sec_max, prop_cardinality=card_dict[sec_max], type="test", parent=doc)
+        _ = odml.Section(name=sec_min, prop_cardinality=card_dict[sec_min], type="test", parent=doc)
+        _ = odml.Section(name=sec_full, prop_cardinality=card_dict[sec_full],
+                         type="test", parent=doc)
+
+        # Test saving to and loading from an XML file
+        odml.save(doc, self.xml_file)
+        xml_doc = odml.load(self.xml_file)
+        self._test_cardinality_load("prop_cardinality", xml_doc, card_dict,
+                                    sec_empty, sec_max, sec_min, sec_full)
+
+        # Test saving to and loading from a JSON file
+        odml.save(doc, self.json_file, "JSON")
+        json_doc = odml.load(self.json_file, "JSON")
+        self._test_cardinality_load("prop_cardinality", json_doc, card_dict,
+                                    sec_empty, sec_max, sec_min, sec_full)
+
+        # Test saving to and loading from a YAML file
+        odml.save(doc, self.yaml_file, "YAML")
+        yaml_doc = odml.load(self.yaml_file, "YAML")
+        self._test_cardinality_load("prop_cardinality", yaml_doc, card_dict,
+                                    sec_empty, sec_max, sec_min, sec_full)
+
     def test_link(self):
         pass
 


### PR DESCRIPTION
The current PR adds the basic cardinality implementation for Section.properties. It provides
- an update in the Section.__init__.
- prop_cardinality accessor methods.
- a set_properties_cardinality convenience method.
- an update to the tools.dict_parser to properly write and read tuples with yaml.
- and registers a Section properties cardinality validation.
- tests for the implemented features.

The PR refers to issue #361. Another PR providing the missing Section.sections cardinality will follow.