### PR TITLE
Implement ignore_errors for DictParser.Reader

### DIFF
--- a/odml/format.py
+++ b/odml/format.py
@@ -82,7 +82,8 @@ class Format(object):
             else:
                 for k, val in self._map.items():
                     self._rev_map[val] = k
-        return self._rev_map.get(name, name)
+
+        return self._rev_map.get(name)
 
     def __iter__(self):
         """ Iterates each python property name """

--- a/odml/tools/dict_parser.py
+++ b/odml/tools/dict_parser.py
@@ -2,6 +2,7 @@
 The dict_parser module provides access to the DictWriter and DictReader class.
 Both handle the conversion of odML documents from and to Python dictionary objects.
 """
+import sys
 
 from .. import format as odmlfmt
 from ..info import FORMAT_VERSION
@@ -233,7 +234,7 @@ class DictReader:
         self.warnings.append(msg)
 
         if self.show_warnings:
-            print(msg)
+            sys.stderr.write("Parser%s\n" % msg)
 
     def to_odml(self, parsed_doc):
         """

--- a/odml/tools/dict_parser.py
+++ b/odml/tools/dict_parser.py
@@ -312,7 +312,14 @@ class DictReader:
                     # Make sure to always use the correct odml format attribute name
                     sec_attrs[odmlfmt.Section.map(attr)] = content
 
-            sec = odmlfmt.Section.create(**sec_attrs)
+            try:
+                sec = odmlfmt.Section.create(**sec_attrs)
+            except Exception as exc:
+                msg = "Error trying to create Section (%s)\n%s" % (sec_attrs, str(exc))
+                self.error(msg)
+                # If recovered in ignore_error mode, return empty list
+                return odml_sections
+
             for prop in sec_props:
                 sec.append(prop)
 
@@ -348,7 +355,11 @@ class DictReader:
                     # Make sure to always use the correct odml format attribute name
                     prop_attrs[odmlfmt.Property.map(attr)] = content
 
-            prop = odmlfmt.Property.create(**prop_attrs)
-            odml_props.append(prop)
+            try:
+                prop = odmlfmt.Property.create(**prop_attrs)
+                odml_props.append(prop)
+            except Exception as exc:
+                msg = "Error trying to create Property (%s)\n%s" % (prop_attrs, str(exc))
+                self.error(msg)
 
         return odml_props

--- a/odml/tools/dict_parser.py
+++ b/odml/tools/dict_parser.py
@@ -319,19 +319,17 @@ class DictReader:
 
             try:
                 sec = odmlfmt.Section.create(**sec_attrs)
+
+                for prop in sec_props:
+                    sec.append(prop)
+
+                for child_sec in children_secs:
+                    sec.append(child_sec)
+
+                odml_sections.append(sec)
             except Exception as exc:
                 msg = "Section not created (%s)\n  %s" % (sec_attrs, str(exc))
                 self.error(msg)
-                # If recovered in ignore_error mode, return empty list
-                return odml_sections
-
-            for prop in sec_props:
-                sec.append(prop)
-
-            for child_sec in children_secs:
-                sec.append(child_sec)
-
-            odml_sections.append(sec)
 
         return odml_sections
 

--- a/odml/tools/dict_parser.py
+++ b/odml/tools/dict_parser.py
@@ -320,7 +320,7 @@ class DictReader:
             try:
                 sec = odmlfmt.Section.create(**sec_attrs)
             except Exception as exc:
-                msg = "Error trying to create Section (%s)\n%s" % (sec_attrs, str(exc))
+                msg = "Section not created (%s)\n  %s" % (sec_attrs, str(exc))
                 self.error(msg)
                 # If recovered in ignore_error mode, return empty list
                 return odml_sections
@@ -364,7 +364,7 @@ class DictReader:
                 prop = odmlfmt.Property.create(**prop_attrs)
                 odml_props.append(prop)
             except Exception as exc:
-                msg = "Error trying to create Property (%s)\n%s" % (prop_attrs, str(exc))
+                msg = "Property not created (%s)\n%s" % (prop_attrs, str(exc))
                 self.error(msg)
 
         return odml_props

--- a/odml/tools/dict_parser.py
+++ b/odml/tools/dict_parser.py
@@ -202,7 +202,10 @@ class DictReader:
         if fmt.revmap(attr):
             return attr
 
-        msg = "Invalid element <%s> inside <%s> tag" % (attr, fmt.__class__.__name__)
+        msg = "Invalid element |%s| inside <%s> tag" % (attr, fmt.__class__.__name__)
+        self.error(msg)
+
+        return None
 
     def error(self, msg):
         """
@@ -228,10 +231,9 @@ class DictReader:
         msg = "warning: %s\n" % msg
 
         self.warnings.append(msg)
+
         if self.show_warnings:
             print(msg)
-
-        return None
 
     def to_odml(self, parsed_doc):
         """

--- a/odml/tools/dict_parser.py
+++ b/odml/tools/dict_parser.py
@@ -8,6 +8,9 @@ from .. import format as odmlfmt
 from ..info import FORMAT_VERSION
 from .parser_utils import InvalidVersionException, ParserException, odml_tuple_export
 
+LABEL_ERROR = "Error"
+LABEL_WARNING = "Warning"
+
 
 def parse_cardinality(vals):
     """
@@ -203,7 +206,7 @@ class DictReader:
         if fmt.revmap(attr):
             return attr
 
-        msg = "Invalid element |%s| inside <%s> tag" % (attr, fmt.__class__.__name__)
+        msg = "Invalid element '%s' inside <%s> tag" % (attr, fmt.__class__.__name__)
         self.error(msg)
 
         return None
@@ -217,19 +220,20 @@ class DictReader:
         :param msg: Error message.
         """
         if self.ignore_errors:
-            return self.warn(msg)
+            return self.warn(msg, LABEL_ERROR)
 
         raise ParserException(msg)
 
-    def warn(self, msg):
+    def warn(self, msg, label=LABEL_WARNING):
         """
         Adds a message to the parsers warnings property. If the parsers show_warnings
         property is set to True, an additional error message will be written
         to sys.stderr.
 
         :param msg: Warning message.
+        :param label: Defined message level, can be 'Error' or 'Warning'. Default is 'Warning'.
         """
-        msg = "warning: %s\n" % msg
+        msg = "%s: %s" % (label, msg)
 
         self.warnings.append(msg)
 

--- a/odml/tools/dict_parser.py
+++ b/odml/tools/dict_parser.py
@@ -197,6 +197,30 @@ class DictReader:
             return attr
 
         msg = "Invalid element <%s> inside <%s> tag" % (attr, fmt.__class__.__name__)
+
+    def error(self, msg):
+        """
+        If the parsers ignore_errors property is set to False, a ParserException
+        will be raised. Otherwise the message is passed to the parsers warning
+        method.
+
+        :param msg: Error message.
+        """
+        if self.ignore_errors:
+            return self.warn(msg)
+
+        raise ParserException(msg)
+
+    def warn(self, msg):
+        """
+        Adds a message to the parsers warnings property. If the parsers show_warnings
+        property is set to True, an additional error message will be written
+        to sys.stderr.
+
+        :param msg: Warning message.
+        """
+        msg = "warning: %s\n" % msg
+
         self.warnings.append(msg)
         if self.show_warnings:
             print(msg)

--- a/odml/tools/dict_parser.py
+++ b/odml/tools/dict_parser.py
@@ -169,15 +169,21 @@ class DictReader:
     A reader to parse dictionaries with odML content into an odml.Document.
     """
 
-    def __init__(self, show_warnings=True):
+    def __init__(self, show_warnings=True, ignore_errors=False):
         """
         :param show_warnings: Toggle whether to print warnings to the command line.
                               Any warnings can be accessed via the Reader's class
                               warnings attribute after parsing is done.
+        :param ignore_errors: To allow loading and fixing of invalid odml files
+                              encountered errors can be converted to warnings
+                              instead. Such a document can only be saved when
+                              all errors have been addressed though.
         """
         self.parsed_doc = None  # Python dictionary object equivalent
-        self.show_warnings = show_warnings
         self.warnings = []
+
+        self.show_warnings = show_warnings
+        self.ignore_errors = ignore_errors
 
     def is_valid_attribute(self, attr, fmt):
         """

--- a/odml/tools/odmlparser.py
+++ b/odml/tools/odmlparser.py
@@ -183,7 +183,8 @@ class ODMLReader:
                     print(err)
                     return None
 
-            par = DictReader(show_warnings=self.show_warnings)
+            par = DictReader(ignore_errors=True,
+                             show_warnings=self.show_warnings)
             self.doc = par.to_odml(self.parsed_doc)
             # Provide original file name via the in memory document
             self.doc.origin_file_name = basename(file)

--- a/test/test_parser_json.py
+++ b/test/test_parser_json.py
@@ -1,5 +1,11 @@
+"""
+This module supplies basic tests for the odml.dict_parser.DictReader
+reading from json files.
+"""
+
 import json
 import os
+import tempfile
 import unittest
 
 from odml.tools import dict_parser
@@ -12,7 +18,26 @@ class TestJSONParser(unittest.TestCase):
         dir_path = os.path.dirname(os.path.realpath(__file__))
         self.basepath = os.path.join(dir_path, "resources")
 
-        self.json_reader = dict_parser.DictReader()
+        self.json_reader = dict_parser.DictReader(show_warnings=False)
+
+        dir_name = os.path.basename(os.path.splitext(__file__)[0])
+        tmp_dir_path = os.path.join(tempfile.gettempdir(), "odml_test", dir_name)
+
+        if not os.path.exists(tmp_dir_path):
+            os.mkdir(tmp_dir_path)
+
+        self.tmp_dir_path = tmp_dir_path
+
+    def _prepare_doc(self, file_name, file_content):
+        file_path = os.path.join(self.tmp_dir_path, file_name)
+
+        with open(file_path, "w") as dump_file:
+            dump_file.write(file_content)
+
+        with open(file_path) as raw_data:
+            parsed_doc = json.load(raw_data)
+
+        return parsed_doc
 
     def test_missing_root(self):
         filename = "missing_root.json"
@@ -46,3 +71,167 @@ class TestJSONParser(unittest.TestCase):
 
         with self.assertRaises(InvalidVersionException):
             _ = self.json_reader.to_odml(parsed_doc)
+
+    def test_invalid_attribute_handling(self):
+        filename = "invalid_attributes.yaml"
+
+        inv_doc_attr = "invalid_doc_attr"
+        inv_sec_attr = "invalid_sec_attr"
+        inv_prop_attr = "invalid_prop_attr"
+
+        file_content = """{
+  "Document": {
+    "id": "6af2a3ec-9f3a-42d6-a59d-95f3ccbaa383",
+    "%s": "i_do_not_exist_on_doc_level",
+    "sections": [
+      {
+        "id": "51f3c79c-a7d7-471e-be16-e085caa851fb",
+        "%s": "i_do_not_exist_on_sec_level",
+        "type": "test",
+        "name": "sec",
+        "sections": [],
+        "properties": [
+          {
+            "id": "c5aed35a-d9ff-437d-82d6-68f0cda8ea94",
+            "%s": "i_do_not_exist_on_prop_level",
+            "name": "prop",
+            "value": [
+              1,
+              2,
+              3
+            ],
+            "type": "int"
+          }
+        ]
+      }
+    ]
+  },
+  "odml-version": "1.1"
+}
+""" % (inv_doc_attr, inv_sec_attr, inv_prop_attr)
+        parsed_doc = self._prepare_doc(filename, file_content)
+
+        # Test ParserException on default parse
+        exc_msg = "Invalid element"
+        with self.assertRaises(ParserException) as exc:
+            _ = self.json_reader.to_odml(parsed_doc)
+        self.assertIn(exc_msg, str(exc.exception))
+
+        # Test success on ignore_error parse
+        self.json_reader.ignore_errors = True
+        doc = self.json_reader.to_odml(parsed_doc)
+
+        self.assertEqual(len(doc.sections), 1)
+        self.assertEqual(len(doc.sections["sec"].properties), 1)
+
+        self.assertEqual(len(self.json_reader.warnings), 3)
+        for msg in self.json_reader.warnings:
+            self.assertIn("Error", msg)
+            self.assertTrue(inv_doc_attr in msg or inv_sec_attr in msg or inv_prop_attr in msg)
+
+    def test_sec_creation_error(self):
+        filename = "broken_section.yaml"
+
+        valid = "valid_sec"
+        invalid = "invalid_sec"
+
+        file_content = """{
+  "Document": {
+    "id": "6af2a3ec-9f3a-42d6-a59d-95f3ccbaa383",
+    "sections": [
+      {
+        "id": "1113c79c-a7d7-471e-be16-e085caa851fb",
+        "name": "sec",
+        "type": "test",
+        "sections": [
+          {
+            "id": "1213c79c-a7d7-471e-be16-e085caa851fb",
+            "name": "%s",
+            "type": "test"
+          },
+          {
+            "id": [
+              "I-am-so-kaputt"
+            ],
+            "name": "%s",
+            "type": "test"
+          }
+        ]
+      }
+    ]
+  },
+  "odml-version": "1.1"
+}
+""" % (valid, invalid)
+        parsed_doc = self._prepare_doc(filename, file_content)
+
+        # Test ParserException on default parse
+        exc_msg = "Section not created"
+        with self.assertRaises(ParserException) as exc:
+            _ = self.json_reader.to_odml(parsed_doc)
+        self.assertIn(exc_msg, str(exc.exception))
+
+        # Test success on ignore_error parse
+        self.json_reader.ignore_errors = True
+        doc = self.json_reader.to_odml(parsed_doc)
+
+        self.assertEqual(len(doc.sections["sec"].sections), 1)
+        self.assertIn(valid, doc.sections["sec"].sections)
+        self.assertNotIn(invalid, doc.sections["sec"].sections)
+
+        self.assertEqual(len(self.json_reader.warnings), 1)
+        for msg in self.json_reader.warnings:
+            self.assertIn("Error", msg)
+            self.assertIn(exc_msg, msg)
+
+    def test_prop_creation_error(self):
+        filename = "broken_property.yaml"
+        file_content = """{
+  "Document": {
+    "id": "6af2a3ec-9f3a-42d6-a59d-95f3ccbaa383",
+    "sections": [
+      {
+        "id": "51f3c79c-a7d7-471e-be16-e085caa851fb",
+        "type": "test",
+        "name": "sec",
+        "properties": [
+          {
+            "id": "121ed35a-d9ff-437d-82d6-68f0cda8ea94",
+            "name": "valid_prop"
+          },
+          {
+            "id": "122ed35a-d9ff-437d-82d6-68f0cda8ea94",
+            "name": "invalid_prop",
+            "value": [
+              "a",
+              "b"
+            ],
+            "type": "int"
+          }
+        ]
+      }
+    ]
+  },
+  "odml-version": "1.1"
+}
+"""
+        parsed_doc = self._prepare_doc(filename, file_content)
+
+        # Test ParserException on default parse
+        exc_msg = "Property not created"
+        with self.assertRaises(ParserException) as exc:
+            _ = self.json_reader.to_odml(parsed_doc)
+        self.assertIn(exc_msg, str(exc.exception))
+
+        # Test success on ignore_error parse
+        self.json_reader.ignore_errors = True
+        doc = self.json_reader.to_odml(parsed_doc)
+
+        self.assertEqual(len(doc.sections["sec"].properties), 1)
+        self.assertIn("valid_prop", doc.sections["sec"].properties)
+        self.assertNotIn("invalid_prop", doc.sections["sec"].properties)
+
+        self.assertEqual(len(self.json_reader.warnings), 1)
+        for msg in self.json_reader.warnings:
+            self.assertIn("Error", msg)
+            self.assertIn(exc_msg, msg)

--- a/test/test_parser_json.py
+++ b/test/test_parser_json.py
@@ -12,6 +12,100 @@ from odml.tools import dict_parser
 from odml.tools.parser_utils import ParserException, InvalidVersionException
 
 
+_INVALID_ATTRIBUTE_HANDLING_DOC = """
+{
+  "Document": {
+    "id": "6af2a3ec-9f3a-42d6-a59d-95f3ccbaa383",
+    "%s": "i_do_not_exist_on_doc_level",
+    "sections": [
+      {
+        "id": "51f3c79c-a7d7-471e-be16-e085caa851fb",
+        "%s": "i_do_not_exist_on_sec_level",
+        "type": "test",
+        "name": "sec",
+        "sections": [],
+        "properties": [
+          {
+            "id": "c5aed35a-d9ff-437d-82d6-68f0cda8ea94",
+            "%s": "i_do_not_exist_on_prop_level",
+            "name": "prop",
+            "value": [
+              1,
+              2,
+              3
+            ],
+            "type": "int"
+          }
+        ]
+      }
+    ]
+  },
+  "odml-version": "1.1"
+}
+""".strip()
+
+_SEC_CREATION_ERROR_DOC = """
+{
+  "Document": {
+    "id": "6af2a3ec-9f3a-42d6-a59d-95f3ccbaa383",
+    "sections": [
+      {
+        "id": "1113c79c-a7d7-471e-be16-e085caa851fb",
+        "name": "sec",
+        "type": "test",
+        "sections": [
+          {
+            "id": "1213c79c-a7d7-471e-be16-e085caa851fb",
+            "name": "%s",
+            "type": "test"
+          },
+          {
+            "id": [
+              "I-am-so-kaputt"
+            ],
+            "name": "%s",
+            "type": "test"
+          }
+        ]
+      }
+    ]
+  },
+  "odml-version": "1.1"
+}
+""".strip()
+
+_PROP_CREATION_ERROR_DOC = """
+{
+  "Document": {
+    "id": "6af2a3ec-9f3a-42d6-a59d-95f3ccbaa383",
+    "sections": [
+      {
+        "id": "51f3c79c-a7d7-471e-be16-e085caa851fb",
+        "type": "test",
+        "name": "sec",
+        "properties": [
+          {
+            "id": "121ed35a-d9ff-437d-82d6-68f0cda8ea94",
+            "name": "valid_prop"
+          },
+          {
+            "id": "122ed35a-d9ff-437d-82d6-68f0cda8ea94",
+            "name": "invalid_prop",
+            "value": [
+              "a",
+              "b"
+            ],
+            "type": "int"
+          }
+        ]
+      }
+    ]
+  },
+  "odml-version": "1.1"
+}
+""".strip()
+
+
 class TestJSONParser(unittest.TestCase):
 
     def setUp(self):
@@ -82,36 +176,7 @@ class TestJSONParser(unittest.TestCase):
         inv_sec_attr = "invalid_sec_attr"
         inv_prop_attr = "invalid_prop_attr"
 
-        file_content = """{
-  "Document": {
-    "id": "6af2a3ec-9f3a-42d6-a59d-95f3ccbaa383",
-    "%s": "i_do_not_exist_on_doc_level",
-    "sections": [
-      {
-        "id": "51f3c79c-a7d7-471e-be16-e085caa851fb",
-        "%s": "i_do_not_exist_on_sec_level",
-        "type": "test",
-        "name": "sec",
-        "sections": [],
-        "properties": [
-          {
-            "id": "c5aed35a-d9ff-437d-82d6-68f0cda8ea94",
-            "%s": "i_do_not_exist_on_prop_level",
-            "name": "prop",
-            "value": [
-              1,
-              2,
-              3
-            ],
-            "type": "int"
-          }
-        ]
-      }
-    ]
-  },
-  "odml-version": "1.1"
-}
-""" % (inv_doc_attr, inv_sec_attr, inv_prop_attr)
+        file_content = _INVALID_ATTRIBUTE_HANDLING_DOC % (inv_doc_attr, inv_sec_attr, inv_prop_attr)
         parsed_doc = self._prepare_doc(filename, file_content)
 
         # Test ParserException on default parse
@@ -138,34 +203,7 @@ class TestJSONParser(unittest.TestCase):
         valid = "valid_sec"
         invalid = "invalid_sec"
 
-        file_content = """{
-  "Document": {
-    "id": "6af2a3ec-9f3a-42d6-a59d-95f3ccbaa383",
-    "sections": [
-      {
-        "id": "1113c79c-a7d7-471e-be16-e085caa851fb",
-        "name": "sec",
-        "type": "test",
-        "sections": [
-          {
-            "id": "1213c79c-a7d7-471e-be16-e085caa851fb",
-            "name": "%s",
-            "type": "test"
-          },
-          {
-            "id": [
-              "I-am-so-kaputt"
-            ],
-            "name": "%s",
-            "type": "test"
-          }
-        ]
-      }
-    ]
-  },
-  "odml-version": "1.1"
-}
-""" % (valid, invalid)
+        file_content = _SEC_CREATION_ERROR_DOC % (valid, invalid)
         parsed_doc = self._prepare_doc(filename, file_content)
 
         # Test ParserException on default parse
@@ -189,36 +227,8 @@ class TestJSONParser(unittest.TestCase):
 
     def test_prop_creation_error(self):
         filename = "broken_property.yaml"
-        file_content = """{
-  "Document": {
-    "id": "6af2a3ec-9f3a-42d6-a59d-95f3ccbaa383",
-    "sections": [
-      {
-        "id": "51f3c79c-a7d7-471e-be16-e085caa851fb",
-        "type": "test",
-        "name": "sec",
-        "properties": [
-          {
-            "id": "121ed35a-d9ff-437d-82d6-68f0cda8ea94",
-            "name": "valid_prop"
-          },
-          {
-            "id": "122ed35a-d9ff-437d-82d6-68f0cda8ea94",
-            "name": "invalid_prop",
-            "value": [
-              "a",
-              "b"
-            ],
-            "type": "int"
-          }
-        ]
-      }
-    ]
-  },
-  "odml-version": "1.1"
-}
-"""
-        parsed_doc = self._prepare_doc(filename, file_content)
+
+        parsed_doc = self._prepare_doc(filename, _PROP_CREATION_ERROR_DOC)
 
         # Test ParserException on default parse
         exc_msg = "Property not created"

--- a/test/test_parser_json.py
+++ b/test/test_parser_json.py
@@ -21,8 +21,11 @@ class TestJSONParser(unittest.TestCase):
         self.json_reader = dict_parser.DictReader(show_warnings=False)
 
         dir_name = os.path.basename(os.path.splitext(__file__)[0])
-        tmp_dir_path = os.path.join(tempfile.gettempdir(), "odml_test", dir_name)
+        tmp_base_path = os.path.join(tempfile.gettempdir(), "odml_test")
+        if not os.path.exists(tmp_base_path):
+            os.mkdir(tmp_base_path)
 
+        tmp_dir_path = os.path.join(tmp_base_path, dir_name)
         if not os.path.exists(tmp_dir_path):
             os.mkdir(tmp_dir_path)
 

--- a/test/test_parser_yaml.py
+++ b/test/test_parser_yaml.py
@@ -1,4 +1,10 @@
+"""
+This module supplies basic tests for the odml.dict_parser.DictReader
+reading from yaml files.
+"""
+
 import os
+import tempfile
 import unittest
 import yaml
 
@@ -13,6 +19,25 @@ class TestYAMLParser(unittest.TestCase):
         self.basepath = os.path.join(dir_path, "resources")
 
         self.yaml_reader = dict_parser.DictReader()
+
+        dir_name = "odml_%s" % os.path.basename(os.path.splitext(__file__)[0])
+        tmp_dir_path = os.path.join(tempfile.gettempdir(), dir_name)
+
+        if not os.path.exists(tmp_dir_path):
+            os.mkdir(tmp_dir_path)
+
+        self.tmp_dir_path = tmp_dir_path
+
+    def _prepare_doc(self, file_name, file_content):
+        file_path = os.path.join(self.tmp_dir_path, file_name)
+
+        with open(file_path, "w") as dump_file:
+            dump_file.write(file_content)
+
+        with open(file_path) as raw_data:
+            parsed_doc = yaml.safe_load(raw_data)
+
+        return parsed_doc
 
     def test_missing_root(self):
         filename = "missing_root.yaml"

--- a/test/test_parser_yaml.py
+++ b/test/test_parser_yaml.py
@@ -12,6 +12,60 @@ from odml.tools import dict_parser
 from odml.tools.parser_utils import ParserException, InvalidVersionException
 
 
+_INVALID_ATTRIBUTE_HANDLING_DOC = """
+Document:
+  id: 82408bdb-1d9d-4fa9-b4dd-ad78831c797c
+  %s: i_do_not_exist_on_doc_level
+  sections:
+  - id: d4f3120a-c02f-4102-a9fe-2e8b77d1d0d2
+    name: sec
+    %s: i_do_not_exist_on_sec_level
+    properties:
+    - id: 18ad5176-2b46-4a08-9b85-eafd6b14fab7
+      name: prop
+      value: []
+      %s: i_do_not_exist_on_prop_level
+    sections: []
+    type: test
+odml-version: '1.1'
+""".strip()
+
+_SEC_CREATION_ERROR_DOC = """
+Document:
+  id: 82408bdb-1d9d-4fa9-b4dd-ad78831c797c
+  sections:
+  - id: 1111a20a-c02f-4102-a9fe-2e8b77d1d0d2
+    name: sec
+    sections:
+    - id: 1121a20a-c02f-4102-a9fe-2e8b77d1d0d2
+      name: %s
+      type: test
+    - id: [I-am-so-kaputt]
+      name: %s
+    type: test
+odml-version: '1.1'
+""".strip()
+
+_PROP_CREATION_ERROR_DOC = """
+Document:
+  id: 82408bdb-1d9d-4fa9-b4dd-ad78831c797c
+  sections:
+  - id: 1111a20a-c02f-4102-a9fe-2e8b77d1d0d2
+    name: sec
+    properties:
+    - id: 1121a20a-c02f-4102-a9fe-2e8b77d1d0d2
+      name: valid_prop
+    - id: 1121a20a-c02f-4102-a9fe-2e8b77d1d0d2
+      name: invalid_prop
+      type: int
+      values:
+      - 'a'
+      - 'b'
+    type: test
+odml-version: '1.1'
+""".strip()
+
+
 class TestYAMLParser(unittest.TestCase):
 
     def setUp(self):
@@ -82,22 +136,7 @@ class TestYAMLParser(unittest.TestCase):
         inv_sec_attr = "invalid_sec_attr"
         inv_prop_attr = "invalid_prop_attr"
 
-        file_content = """Document:
-  id: 82408bdb-1d9d-4fa9-b4dd-ad78831c797c
-  %s: i_do_not_exist_on_doc_level
-  sections:
-  - id: d4f3120a-c02f-4102-a9fe-2e8b77d1d0d2
-    name: sec
-    %s: i_do_not_exist_on_sec_level
-    properties:
-    - id: 18ad5176-2b46-4a08-9b85-eafd6b14fab7
-      name: prop
-      value: []
-      %s: i_do_not_exist_on_prop_level
-    sections: []
-    type: test
-odml-version: '1.1'
-""" % (inv_doc_attr, inv_sec_attr, inv_prop_attr)
+        file_content = _INVALID_ATTRIBUTE_HANDLING_DOC % (inv_doc_attr, inv_sec_attr, inv_prop_attr)
 
         parsed_doc = self._prepare_doc(filename, file_content)
 
@@ -125,20 +164,8 @@ odml-version: '1.1'
         valid = "valid_sec"
         invalid = "invalid_sec"
 
-        file_content = """Document:
-  id: 82408bdb-1d9d-4fa9-b4dd-ad78831c797c
-  sections:
-  - id: 1111a20a-c02f-4102-a9fe-2e8b77d1d0d2
-    name: sec
-    sections:
-    - id: 1121a20a-c02f-4102-a9fe-2e8b77d1d0d2
-      name: %s
-      type: test
-    - id: [I-am-so-kaputt]
-      name: %s
-    type: test
-odml-version: '1.1'
-""" % (valid, invalid)
+        file_content = _SEC_CREATION_ERROR_DOC % (valid, invalid)
+
         parsed_doc = self._prepare_doc(filename, file_content)
 
         # Test ParserException on default parse
@@ -162,24 +189,8 @@ odml-version: '1.1'
 
     def test_prop_creation_error(self):
         filename = "broken_property.yaml"
-        file_content = """Document:
-  id: 82408bdb-1d9d-4fa9-b4dd-ad78831c797c
-  sections:
-  - id: 1111a20a-c02f-4102-a9fe-2e8b77d1d0d2
-    name: sec
-    properties:
-    - id: 1121a20a-c02f-4102-a9fe-2e8b77d1d0d2
-      name: valid_prop
-    - id: 1121a20a-c02f-4102-a9fe-2e8b77d1d0d2
-      name: invalid_prop
-      type: int
-      values:
-      - 'a'
-      - 'b'
-    type: test
-odml-version: '1.1'
-"""
-        parsed_doc = self._prepare_doc(filename, file_content)
+
+        parsed_doc = self._prepare_doc(filename, _PROP_CREATION_ERROR_DOC)
 
         # Test ParserException on default parse
         exc_msg = "Property not created"

--- a/test/test_parser_yaml.py
+++ b/test/test_parser_yaml.py
@@ -21,8 +21,11 @@ class TestYAMLParser(unittest.TestCase):
         self.yaml_reader = dict_parser.DictReader(show_warnings=False)
 
         dir_name = os.path.basename(os.path.splitext(__file__)[0])
-        tmp_dir_path = os.path.join(tempfile.gettempdir(), "odml_test", dir_name)
+        tmp_base_path = os.path.join(tempfile.gettempdir(), "odml_test")
+        if not os.path.exists(tmp_base_path):
+            os.mkdir(tmp_base_path)
 
+        tmp_dir_path = os.path.join(tmp_base_path, dir_name)
         if not os.path.exists(tmp_dir_path):
             os.mkdir(tmp_dir_path)
 

--- a/test/test_terminology.py
+++ b/test/test_terminology.py
@@ -3,10 +3,11 @@ Tests functions and classes from the odml terminology module.
 """
 
 import os
-import unittest
 import tempfile
+import unittest
 
 from glob import glob
+from sys import platform
 from time import sleep
 try:
     from urllib.request import pathname2url
@@ -104,9 +105,13 @@ class TestTerminology(unittest.TestCase):
             self.assertIn(curr_file, load_map)
             self.assertEqual(orig_map[curr_file], load_map[curr_file])
 
+        sleep_time = 0.5
+        if platform == "darwin":
+            sleep_time = 2
+
         # Sleep is needed since the tests might be too fast to result in a
-        # different file mtime. macOS seems to require sleep time > 0.700.
-        sleep(0.800)
+        # different file mtime. Travis macOS seems to require sleep time > 1s.
+        sleep(sleep_time)
 
         # Test refresh loads same cached files but changes them.
         # Different mtimes and id strings are sufficient.


### PR DESCRIPTION
The XMLParser.Reader comes with an option to ignore errors when opening a file while notifying the user with all encountered odml format problems, enabling users to fix problematic odml files using the odml library instead of having to directly manipulate the file content.

This option has now been added to the DictParser.Reader as well, also allowing to open and fix problematic odml JSON and YAML files.

The PR
- adds all necessary changes in the DictParser.Reader to enable ignoring errors, collecting warnings and printing corresponding notifications. These changes close issue #367.
- changes the ODMLParser.Reader for JSON and YAML to now ignore_errors by default e.g. when using the `odml.load` function.
- fixes a bug in `format.revmap` where the reverse mapping of an odml attribute would always return the case that the attribute is part of the format, even if it was not.
- adds tests for parsing problematic JSON and YAML odml files.

Don't be afraid, most of the changes in this PR again increase the test coverage.
