### PR TITLE
Validation changes

### DIFF
--- a/odml/doc.py
+++ b/odml/doc.py
@@ -8,6 +8,7 @@ from . import base
 from . import dtypes
 from . import format as fmt
 from . import terminology
+from . import validation
 from .tools.doc_inherit import inherit_docstring, allow_inherit_docstring
 
 
@@ -151,6 +152,14 @@ class BaseDocument(base.Sectionable):
                 sec.link = sec._link
             if sec._include is not None:
                 sec.include = sec._include
+
+    def validate(self):
+        """
+        Runs a validation on itself and returns the Validation object.
+
+        :return: odml.Validation
+        """
+        return validation.Validation(self)
 
     @inherit_docstring
     def get_terminology_equivalent(self):

--- a/odml/property.py
+++ b/odml/property.py
@@ -569,11 +569,12 @@ class BaseProperty(base.BaseObject):
         is respected and prints a warning message otherwise.
         """
         valid = validation.Validation(self)
+        val_id = validation.ValidationID.property_values_cardinality
 
         # Make sure to display only warnings of the current property
-        res = [curr for curr in valid.errors if self.id == curr.obj.id]
-        for err in res:
-            print("%s: %s" % (err.rank.capitalize(), err.msg))
+        for curr in valid.errors:
+            if curr.validation_id == val_id and self.id == curr.obj.id:
+                print("%s: %s" % (curr.rank.capitalize(), curr.msg))
 
     def set_values_cardinality(self, min_val=None, max_val=None):
         """

--- a/odml/property.py
+++ b/odml/property.py
@@ -213,6 +213,11 @@ class BaseProperty(base.BaseObject):
         if self.name == new_name:
             return
 
+        # Make sure name cannot be set to None or empty
+        if not new_name:
+            self._name = self._id
+            return
+
         curr_parent = self.parent
         if hasattr(curr_parent, "properties") and new_name in curr_parent.properties:
 

--- a/odml/property.py
+++ b/odml/property.py
@@ -574,7 +574,7 @@ class BaseProperty(base.BaseObject):
         is respected and prints a warning message otherwise.
         """
         valid = validation.Validation(self)
-        val_id = validation.ValidationID.property_values_cardinality
+        val_id = validation.IssueID.property_values_cardinality
 
         # Make sure to display only warnings of the current property
         for curr in valid.errors:

--- a/odml/section.py
+++ b/odml/section.py
@@ -171,6 +171,11 @@ class BaseSection(base.Sectionable):
         if self.name == new_value:
             return
 
+        # Make sure name cannot be set to None or empty
+        if not new_value:
+            self._name = self._id
+            return
+
         curr_parent = self.parent
         if hasattr(curr_parent, "sections") and new_value in curr_parent.sections:
             raise KeyError("Object with the same name already exists!")

--- a/odml/section.py
+++ b/odml/section.py
@@ -416,10 +416,12 @@ class BaseSection(base.Sectionable):
         is respected and prints a warning message otherwise.
         """
         valid = validation.Validation(self)
+        val_id = validation.ValidationID.section_sections_cardinality
+
         # Make sure to display only warnings of the current section
-        res = [curr for curr in valid.errors if self.id == curr.obj.id]
-        for err in res:
-            print("%s: %s" % (err.rank.capitalize(), err.msg))
+        for curr in valid.errors:
+            if curr.validation_id == val_id and self.id == curr.obj.id:
+                print("%s: %s" % (curr.rank.capitalize(), curr.msg))
 
     @property
     def prop_cardinality(self):
@@ -469,10 +471,12 @@ class BaseSection(base.Sectionable):
         is respected and prints a warning message otherwise.
         """
         valid = validation.Validation(self)
+        val_id = validation.ValidationID.section_properties_cardinality
+
         # Make sure to display only warnings of the current section
-        res = [curr for curr in valid.errors if self.id == curr.obj.id]
-        for err in res:
-            print("%s: %s" % (err.rank.capitalize(), err.msg))
+        for curr in valid.errors:
+            if curr.validation_id == val_id and self.id == curr.obj.id:
+                print("%s: %s" % (curr.rank.capitalize(), curr.msg))
 
     @inherit_docstring
     def get_terminology_equivalent(self):

--- a/odml/section.py
+++ b/odml/section.py
@@ -421,7 +421,7 @@ class BaseSection(base.Sectionable):
         is respected and prints a warning message otherwise.
         """
         valid = validation.Validation(self)
-        val_id = validation.ValidationID.section_sections_cardinality
+        val_id = validation.IssueID.section_sections_cardinality
 
         # Make sure to display only warnings of the current section
         for curr in valid.errors:
@@ -476,7 +476,7 @@ class BaseSection(base.Sectionable):
         is respected and prints a warning message otherwise.
         """
         valid = validation.Validation(self)
-        val_id = validation.ValidationID.section_properties_cardinality
+        val_id = validation.IssueID.section_properties_cardinality
 
         # Make sure to display only warnings of the current section
         for curr in valid.errors:

--- a/odml/tools/odmlparser.py
+++ b/odml/tools/odmlparser.py
@@ -70,8 +70,8 @@ class ODMLWriter:
 
         report = validation.report()
         if report:
-            msg += "The saved Document contains formal issues."
-            msg += " Run 'odml.validation.Validation(doc)' to resolve them.\n%s" % report
+            msg += "The saved Document contains unresolved issues."
+            msg += " Run the Documents 'validate' method to access them.\n%s" % report
             warnings.warn(msg)
 
         with open(filename, 'w') as file:
@@ -164,8 +164,8 @@ class ODMLReader:
     def _validation_warning(self):
         report = Validation(self.doc).report()
         if report:
-            msg = "The loaded Document contains formal issues."
-            msg += "Run 'odml.validation.Validation(doc)' to resolve them.\n%s" % report
+            msg = "The loaded Document contains unresolved issues."
+            msg += " Run the Documents 'validate' method to access them.\n%s" % report
             warnings.warn(msg)
 
     def from_file(self, file, doc_format=None):
@@ -244,8 +244,8 @@ class ODMLReader:
             for doc in self.doc:
                 report = Validation(doc).report()
                 if report:
-                    msg = "The loaded Document contains formal issues."
-                    msg += "Run 'odml.validation.Validation(doc)' to resolve them.\n%s" % report
+                    msg = "The loaded Document contains unresolved issues."
+                    msg += " Run the Documents 'validate' method to access them.\n%s" % report
                     warnings.warn(msg)
 
             return self.doc
@@ -313,8 +313,8 @@ class ODMLReader:
             for doc in self.doc:
                 report = Validation(doc).report()
                 if report:
-                    msg = "The loaded Document contains formal issues."
-                    msg += "Run 'odml.validation.Validation(doc)' to resolve them.\n%s" % report
+                    msg = "The loaded Document contains unresolved issues."
+                    msg += " Run the Documents 'validate' method to access them.\n%s" % report
                     warnings.warn(msg)
 
             return self.doc

--- a/odml/tools/odmlparser.py
+++ b/odml/tools/odmlparser.py
@@ -7,6 +7,7 @@ All supported formats can be found in parser_utils.SUPPORTED_PARSERS.
 import datetime
 import json
 import sys
+import warnings
 
 from os.path import basename
 
@@ -61,10 +62,17 @@ class ODMLWriter:
         msg = ""
         for err in validation.errors:
             if err.is_error:
-                msg += "\n\t- %s %s: %s" % (err.obj, err.rank, err.msg)
+                # msg += "\n\t- %s %s: %s" % (err.obj, err.rank, err.msg)
+                msg += "\n- %s" % err
         if msg != "":
             msg = "Resolve document validation errors before saving %s" % msg
             raise ParserException(msg)
+
+        report = validation.report()
+        if report:
+            msg += "The saved Document contains formal issues."
+            msg += " Run 'odml.Validation' to resolve them.\n%s" % report
+            warnings.warn(msg)
 
         with open(filename, 'w') as file:
             # Add XML header to support odML stylesheets.
@@ -153,6 +161,13 @@ class ODMLReader:
         self.show_warnings = show_warnings
         self.warnings = []
 
+    def _validation_warning(self):
+        report = Validation(self.doc).report()
+        if report:
+            msg = "The loaded Document contains formal issues."
+            msg += "Run 'odml.Validation' to resolve them.\n%s" % report
+            warnings.warn(msg)
+
     def from_file(self, file, doc_format=None):
         """
         Loads an odML document from a file. The ODMLReader.parser specifies the
@@ -171,6 +186,11 @@ class ODMLReader:
                                       show_warnings=self.show_warnings)
             self.warnings = par.warnings
             self.doc = par.from_file(file)
+
+            # Print validation warnings after parsing
+            if self.show_warnings:
+                self._validation_warning()
+
             return self.doc
 
         if self.parser == 'YAML':
@@ -188,6 +208,11 @@ class ODMLReader:
             self.doc = par.to_odml(self.parsed_doc)
             # Provide original file name via the in memory document
             self.doc.origin_file_name = basename(file)
+
+            # Print validation warnings after parsing
+            if self.show_warnings:
+                self._validation_warning()
+
             return self.doc
 
         if self.parser == 'JSON':
@@ -202,13 +227,27 @@ class ODMLReader:
             self.doc = par.to_odml(self.parsed_doc)
             # Provide original file name via the in memory document
             self.doc.origin_file_name = basename(file)
+
+            # Print validation warnings after parsing
+            if self.show_warnings:
+                self._validation_warning()
+
             return self.doc
 
         if self.parser == 'RDF':
             if not doc_format:
                 raise ValueError("Format of the rdf file was not specified")
 
+            # Importing from an RDF graph can return multiple documents
             self.doc = RDFReader().from_file(file, doc_format)
+
+            for doc in self.doc:
+                report = Validation(doc).report()
+                if report:
+                    msg = "The loaded Document contains formal issues."
+                    msg += "Run 'odml.Validation' to resolve them.\n%s" % report
+                    warnings.warn(msg)
+
             return self.doc
 
     def from_string(self, string, doc_format=None):
@@ -227,6 +266,11 @@ class ODMLReader:
 
         if self.parser == 'XML':
             self.doc = xmlparser.XMLReader().from_string(string)
+
+            # Print validation warnings after parsing
+            if self.show_warnings:
+                self._validation_warning()
+
             return self.doc
 
         if self.parser == 'YAML':
@@ -237,6 +281,11 @@ class ODMLReader:
                 return
 
             self.doc = DictReader().to_odml(self.parsed_doc)
+
+            # Print validation warnings after parsing
+            if self.show_warnings:
+                self._validation_warning()
+
             return self.doc
 
         if self.parser == 'JSON':
@@ -247,13 +296,27 @@ class ODMLReader:
                 return
 
             self.doc = DictReader().to_odml(self.parsed_doc)
+
+            # Print validation warnings after parsing
+            if self.show_warnings:
+                self._validation_warning()
+
             return self.doc
 
         if self.parser == 'RDF':
             if not doc_format:
                 raise ValueError("Format of the rdf file was not specified")
 
+            # Importing from an RDF graph can return multiple documents
             self.doc = RDFReader().from_string(string, doc_format)
+
+            for doc in self.doc:
+                report = Validation(doc).report()
+                if report:
+                    msg = "The loaded Document contains formal issues."
+                    msg += "Run 'odml.Validation' to resolve them.\n%s" % report
+                    warnings.warn(msg)
+
             return self.doc
 
 

--- a/odml/tools/odmlparser.py
+++ b/odml/tools/odmlparser.py
@@ -71,7 +71,7 @@ class ODMLWriter:
         report = validation.report()
         if report:
             msg += "The saved Document contains formal issues."
-            msg += " Run 'odml.Validation' to resolve them.\n%s" % report
+            msg += " Run 'odml.validation.Validation(doc)' to resolve them.\n%s" % report
             warnings.warn(msg)
 
         with open(filename, 'w') as file:
@@ -165,7 +165,7 @@ class ODMLReader:
         report = Validation(self.doc).report()
         if report:
             msg = "The loaded Document contains formal issues."
-            msg += "Run 'odml.Validation' to resolve them.\n%s" % report
+            msg += "Run 'odml.validation.Validation(doc)' to resolve them.\n%s" % report
             warnings.warn(msg)
 
     def from_file(self, file, doc_format=None):
@@ -245,7 +245,7 @@ class ODMLReader:
                 report = Validation(doc).report()
                 if report:
                     msg = "The loaded Document contains formal issues."
-                    msg += "Run 'odml.Validation' to resolve them.\n%s" % report
+                    msg += "Run 'odml.validation.Validation(doc)' to resolve them.\n%s" % report
                     warnings.warn(msg)
 
             return self.doc
@@ -314,7 +314,7 @@ class ODMLReader:
                 report = Validation(doc).report()
                 if report:
                     msg = "The loaded Document contains formal issues."
-                    msg += "Run 'odml.Validation' to resolve them.\n%s" % report
+                    msg += "Run 'odml.validation.Validation(doc)' to resolve them.\n%s" % report
                     warnings.warn(msg)
 
             return self.doc

--- a/odml/validation.py
+++ b/odml/validation.py
@@ -18,7 +18,7 @@ LABEL_ERROR = 'error'
 LABEL_WARNING = 'warning'
 
 
-class ValidationID(Enum):
+class IssueID(Enum):
     """
     IDs identifying registered validation handlers.
     """
@@ -239,7 +239,7 @@ def object_required_attributes(obj):
 
     :param obj: document, section or property.
     """
-    validation_id = ValidationID.object_required_attributes
+    validation_id = IssueID.object_required_attributes
 
     args = obj.format().arguments
     for arg in args:
@@ -264,7 +264,7 @@ def section_type_must_be_defined(sec):
 
     :param sec: odml.Section.
     """
-    validation_id = ValidationID.section_type_must_be_defined
+    validation_id = IssueID.section_type_must_be_defined
 
     if sec.type and sec.type == "n.s.":
         yield ValidationError(sec, "Section type not specified", LABEL_WARNING, validation_id)
@@ -280,7 +280,7 @@ def section_repository_present(sec):
     1. warn, if a section has no repository or
     2. the section type is not present in the repository
     """
-    validation_id = ValidationID.section_repository_present
+    validation_id = IssueID.section_repository_present
 
     repo = sec.get_repository()
     if repo is None:
@@ -327,7 +327,7 @@ def section_unique_ids(parent, id_map=None):
     :param parent: odML Document or Section
     :param id_map: "id":"odML object / path" dictionary
     """
-    validation_id = ValidationID.section_unique_ids
+    validation_id = IssueID.section_unique_ids
 
     if not id_map:
         id_map = {}
@@ -358,7 +358,7 @@ def property_unique_ids(section, id_map=None):
     :param section: odML Section
     :param id_map: "id":"odML object / path" dictionary
     """
-    validation_id = ValidationID.property_unique_ids
+    validation_id = IssueID.property_unique_ids
 
     if not id_map:
         id_map = {}
@@ -406,7 +406,7 @@ def section_unique_name_type(obj):
     """
     for i in object_unique_names(
             obj,
-            validation_id=ValidationID.section_unique_name_type,
+            validation_id=IssueID.section_unique_name_type,
             attr=lambda x: (x.name, x.type),
             children=lambda x: x.sections,
             msg="name/type combination must be unique"):
@@ -420,7 +420,7 @@ def property_unique_names(obj):
     :param obj: odml class instance the validation is applied on.
     """
     for i in object_unique_names(obj,
-                                 validation_id=ValidationID.property_unique_name,
+                                 validation_id=IssueID.property_unique_name,
                                  children=lambda x: x.properties):
         yield i
 
@@ -436,7 +436,7 @@ def object_name_readable(obj):
 
     :param obj: odml.Section or odml.Property.
     """
-    validation_id = ValidationID.object_name_readable
+    validation_id = IssueID.object_name_readable
 
     if obj.name == obj.id:
         yield ValidationError(obj, "Name not assigned", LABEL_WARNING, validation_id)
@@ -452,7 +452,7 @@ def property_terminology_check(prop):
     2. warn, if there are multiple values with different units or the unit does
        not match the one in the terminology.
     """
-    validation_id = ValidationID.property_terminology_check
+    validation_id = IssueID.property_terminology_check
 
     if not prop.parent:
         return
@@ -475,7 +475,7 @@ def property_dependency_check(prop):
     Produces a warning if the dependency attribute refers to a non-existent attribute
     or the dependency_value does not match.
     """
-    validation_id = ValidationID.property_dependency_check
+    validation_id = IssueID.property_dependency_check
 
     if not prop.parent:
         return
@@ -506,7 +506,7 @@ def property_values_check(prop):
 
     :param prop: property the validation is applied on.
     """
-    validation_id = ValidationID.property_values_check
+    validation_id = IssueID.property_values_check
 
     if prop.dtype is not None and prop.dtype != "":
         dtype = prop.dtype
@@ -540,7 +540,7 @@ def property_values_string_check(prop):
 
     :param prop: property the validation is applied on.
     """
-    validation_id = ValidationID.property_values_string_check
+    validation_id = IssueID.property_values_string_check
 
     if prop.dtype != "string" or not prop.values:
         return
@@ -636,7 +636,7 @@ def section_properties_cardinality(obj):
 
     :return: Yields a ValidationError warning, if a set cardinality is not met.
     """
-    validation_id = ValidationID.section_properties_cardinality
+    validation_id = IssueID.section_properties_cardinality
 
     err = _cardinality_validation(obj, obj.prop_cardinality, 'properties',
                                   LABEL_WARNING, validation_id)
@@ -655,7 +655,7 @@ def section_sections_cardinality(obj):
 
     :return: Yields a ValidationError warning, if a set cardinality is not met.
     """
-    validation_id = ValidationID.section_sections_cardinality
+    validation_id = IssueID.section_sections_cardinality
 
     err = _cardinality_validation(obj, obj.sec_cardinality, 'sections',
                                   LABEL_WARNING, validation_id)
@@ -674,7 +674,7 @@ def property_values_cardinality(obj):
 
     :return: Yields a ValidationError warning, if a set cardinality is not met.
     """
-    validation_id = ValidationID.property_values_cardinality
+    validation_id = IssueID.property_values_cardinality
 
     err = _cardinality_validation(obj, obj.val_cardinality, 'values',
                                   LABEL_WARNING, validation_id)

--- a/odml/validation.py
+++ b/odml/validation.py
@@ -9,6 +9,11 @@ from enum import Enum
 
 from . import dtypes
 
+try:
+    unicode = unicode
+except NameError:
+    unicode = str
+
 LABEL_ERROR = 'error'
 LABEL_WARNING = 'warning'
 
@@ -83,9 +88,15 @@ class ValidationError(object):
         return self.obj.get_path()
 
     def __repr__(self):
-        return "<ValidationError(%s):%s '%s'>" % (self.rank,
-                                                  self.obj,
-                                                  self.msg)
+        # Cleanup the odml object print strings
+        print_str = unicode(self.obj).split()[0].split("[")[0].split(":")[0]
+        # Document has no name attribute and should not print id or name info
+        if hasattr(self.obj, "name"):
+            if self.obj.name and self.obj.name != self.obj.id:
+                print_str = "%s[%s]" % (print_str, self.obj.name)
+            else:
+                print_str = "%s[%s]" % (print_str, self.obj.id)
+        return "Validation%s: %s '%s'" % (self.rank.capitalize(), print_str, self.msg)
 
 
 class Validation(object):

--- a/odml/validation.py
+++ b/odml/validation.py
@@ -409,7 +409,7 @@ def object_name_readable(obj):
     validation_id = ValidationID.object_name_readable
 
     if obj.name == obj.id:
-        yield ValidationError(obj, "Name should be readable", LABEL_WARNING, validation_id)
+        yield ValidationError(obj, "Name not assigned", LABEL_WARNING, validation_id)
 
 
 Validation.register_handler('section', object_name_readable)

--- a/odml/validation.py
+++ b/odml/validation.py
@@ -4,10 +4,47 @@ Generic odML validation framework.
 """
 
 import re
+
+from enum import Enum
+
 from . import dtypes
 
 LABEL_ERROR = 'error'
 LABEL_WARNING = 'warning'
+
+
+class ValidationID(Enum):
+    """
+    IDs identifying registered validation handlers.
+    """
+    unspecified = 1
+
+    # Required attributes validations
+    object_required_attributes = 10
+    section_type_must_be_defined = 11
+
+    # Unique id, name and type validations
+    section_unique_ids = 20
+    property_unique_ids = 21
+    section_unique_name_type = 22
+    property_unique_name = 23
+
+    # Good form validations
+    object_name_readable = 30
+
+    # Property specific validations
+    property_terminology_check = 40
+    property_dependency_check = 41
+    property_values_check = 42
+    property_values_string_check = 43
+
+    # Cardinality validations
+    section_properties_cardinality = 50
+    section_sections_cardinality = 51
+    property_values_cardinality = 52
+
+    # Optional validations
+    section_repository_present = 60
 
 
 class ValidationError(object):

--- a/odml/validation.py
+++ b/odml/validation.py
@@ -25,31 +25,31 @@ class IssueID(Enum):
     unspecified = 1
 
     # Required attributes validations
-    object_required_attributes = 10
-    section_type_must_be_defined = 11
+    object_required_attributes = 110
+    section_type_must_be_defined = 111
 
     # Unique id, name and type validations
-    section_unique_ids = 20
-    property_unique_ids = 21
-    section_unique_name_type = 22
-    property_unique_name = 23
+    section_unique_ids = 120
+    property_unique_ids = 121
+    section_unique_name_type = 122
+    property_unique_name = 123
 
     # Good form validations
-    object_name_readable = 30
+    object_name_readable = 130
 
     # Property specific validations
-    property_terminology_check = 40
-    property_dependency_check = 41
-    property_values_check = 42
-    property_values_string_check = 43
+    property_terminology_check = 140
+    property_dependency_check = 141
+    property_values_check = 142
+    property_values_string_check = 143
 
     # Cardinality validations
-    section_properties_cardinality = 50
-    section_sections_cardinality = 51
-    property_values_cardinality = 52
+    section_properties_cardinality = 150
+    section_sections_cardinality = 151
+    property_values_cardinality = 152
 
     # Optional validations
-    section_repository_present = 60
+    section_repository_present = 160
 
 
 class ValidationError(object):

--- a/odml/validation.py
+++ b/odml/validation.py
@@ -25,31 +25,31 @@ class IssueID(Enum):
     unspecified = 1
 
     # Required attributes validations
-    object_required_attributes = 110
-    section_type_must_be_defined = 111
+    object_required_attributes = 101
+    section_type_must_be_defined = 102
 
     # Unique id, name and type validations
-    section_unique_ids = 120
-    property_unique_ids = 121
-    section_unique_name_type = 122
-    property_unique_name = 123
+    section_unique_ids = 200
+    property_unique_ids = 201
+    section_unique_name_type = 202
+    property_unique_name = 203
 
     # Good form validations
-    object_name_readable = 130
+    object_name_readable = 300
 
     # Property specific validations
-    property_terminology_check = 140
-    property_dependency_check = 141
-    property_values_check = 142
-    property_values_string_check = 143
+    property_terminology_check = 400
+    property_dependency_check = 401
+    property_values_check = 402
+    property_values_string_check = 403
 
     # Cardinality validations
-    section_properties_cardinality = 150
-    section_sections_cardinality = 151
-    property_values_cardinality = 152
+    section_properties_cardinality = 500
+    section_sections_cardinality = 501
+    property_values_cardinality = 502
 
     # Optional validations
-    section_repository_present = 160
+    section_repository_present = 600
 
 
 class ValidationError(object):

--- a/odml/validation.py
+++ b/odml/validation.py
@@ -173,6 +173,36 @@ class Validation(object):
             for prop in sec.properties:
                 self.validate(prop)
 
+    def report(self):
+        """
+        Validates the registered object and returns a results report.
+        """
+        self.run_validation()
+
+        err_count = 0
+        reduce = set()
+        sec_count = 0
+        prop_count = 0
+
+        for i in self.errors:
+            if i.is_error:
+                err_count += 1
+
+            if i.obj not in reduce and 'section' in str(i.obj).lower():
+                sec_count += 1
+            elif i.obj not in reduce and 'property' in str(i.obj).lower():
+                prop_count += 1
+
+            reduce.add(i.obj)
+
+        warn_count = len(self.errors) - err_count
+        msg = ""
+        if err_count or warn_count:
+            msg = "Validation found %s errors and %s warnings" % (err_count, warn_count)
+            msg += " in %s Sections and %s Properties." % (sec_count, prop_count)
+
+        return msg
+
     def register_custom_handler(self, klass, handler):
         """
         Adds a validation handler for an odml class. The handler is called in the

--- a/odml/validation.py
+++ b/odml/validation.py
@@ -191,6 +191,8 @@ def section_type_must_be_defined(sec):
 Validation.register_handler('section', section_type_must_be_defined)
 
 
+# The Section repository present is no longer part of the default validation
+# and should be added on demand.
 def section_repository_present(sec):
     """
     1. warn, if a section has no repository or
@@ -212,9 +214,6 @@ def section_repository_present(sec):
     if tsec is None:
         msg = "Section type '%s' not found in terminology" % sec.type
         yield ValidationError(sec, msg, LABEL_WARNING)
-
-
-Validation.register_handler('section', section_repository_present)
 
 
 def document_unique_ids(doc):

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -276,7 +276,7 @@ class TestValidation(unittest.TestCase):
         sec = odml.Section("sec", parent=doc)
         sec.name = sec.id
         res = Validate(doc)
-        self.assertError(res, "Name should be readable")
+        self.assertError(res, "Name not assigned")
 
     def test_property_name_readable(self):
         """
@@ -287,7 +287,7 @@ class TestValidation(unittest.TestCase):
         prop = odml.Property("prop", parent=sec)
         prop.name = prop.id
         res = Validate(doc)
-        self.assertError(res, "Name should be readable")
+        self.assertError(res, "Name not assigned")
 
     def test_standalone_section(self):
         """

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -467,3 +467,27 @@ class TestValidation(unittest.TestCase):
         path = os.path.join(RES_DIR, "validation_dtypes.yaml")
         doc = odml.load(path, "YAML")
         self.load_dtypes_validation(doc)
+
+    def test_section_in_terminology(self):
+        """
+        Test optional section in terminology validation.
+        """
+        doc = samplefile.parse("""s1[T1]""")
+
+        # Set up custom validation and add section_repository_present handler
+        res = odml.validation.Validation(doc, validate=False, reset=True)
+        handler = odml.validation.section_repository_present
+        res.register_custom_handler('section', handler)
+
+        res.run_validation()
+        self.assertError(res, "A section should have an associated repository",
+                         filter_rep=False)
+
+        odml.terminology.terminologies['map'] = samplefile.parse("""
+        s0[t0]
+        - S1[T1]
+        """)
+        doc.sections[0].repository = 'map'
+        res = Validate(doc)
+        # self.assertEqual(list(self.filter_mapping_errors(res.errors)), [])
+        self.assertEqual(res.errors, [])

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -195,21 +195,6 @@ class TestValidation(unittest.TestCase):
 
         self.assertTrue(found)
 
-    def test_section_in_terminology(self):
-        doc = samplefile.parse("""s1[T1]""")
-        res = Validate(doc)
-        self.assertError(res, "A section should have an associated repository",
-                         filter_rep=False)
-
-        odml.terminology.terminologies['map'] = samplefile.parse("""
-        s0[t0]
-        - S1[T1]
-        """)
-        doc.sections[0].repository = 'map'
-        res = Validate(doc)
-        # self.assertEqual(list(self.filter_mapping_errors(res.errors)), [])
-        self.assertEqual(res.errors, [])
-
     def test_uniques(self):
         self.assertRaises(KeyError, samplefile.parse, """
             s1[t1]


### PR DESCRIPTION
This PR contains a couple of potentially controversial points and should be discussed here before merging and addresses the issues #377, #378 and #379.

Changes to the Validation class enabling Custom Validation Instances sneaked itself in at an [earlier commit](https://github.com/G-Node/python-odml/commit/f6fefe07298113f2c77cbffe2ddf1a13500eaae0) and should be taken into account when reviewing this PR. Check changes in `Validation.__init__()` and `run_validation` and `register_custom_handler` methods. Sorry for the mixup...

This PR 
- adds a validation_id enum class.
- adds individual validation_ids to each validation to make them identifyable via an ID rather than by their error message.
- adds a validation_id field to the ValidationError as well.
- uses the validation_id when running cardinality validations and  now prints only messages when a cardinality is violated. Before a user would be spammed with different validation warnings as well.
- shortens the general `ValidationError.__repr__` to make it more convenient to read. 
- adds a `report` method to the `Validation` class to provide a general overview of collected errors and warnings.
- uses the `report` method whenever a Document is saved or loaded via the `ODMLParser` resulting in a `warnings.warn` message:
```
UserWarning: The saved Document contains formal issues. Run 'odml.validation.Validation(doc)' to resolve them.
Validation found 0 errors and 3 warnings in 1 Sections and 1 Properties.
```
- changes the `object_name_readable` validation message to `Name not assigned` to make it clearer to the user that an object name should be set.
- removes the `section_repository_present` validation from the default validation list. Since Sections rarely have repositories set, this validation can get a bit spammy when validating a Document.

Fixes:
- An unrelated change in `Section` and `Property` is added: when trying to set the `name` attribute to `None`, it now silently sets the name to `id` instead, since `name` must not be empty. It would be set to `id` on load and can cause `AttributeError` exceptions with some methods if its not set.

Points for discussion before merging:
- [x] should we keep the standalone Validation class features introduced in an earlier commit, even though we are not using them right now? They might be useful for future standalone validations.
- [x] should we keep the validation warning message on `save` and `load` as it is now or make any changes to it?
- [x] this validation is only run when using the `ODMLParser`, `odml.load` and `odml.save`, not when using the underlying `XMLParser` for XML or `DictParser` for YAML and JSON to keep the validations out of the core parsers. Any different opinions on this point?