### PR TITLE
List-Style Tuple Integration

### DIFF
--- a/odml/property.py
+++ b/odml/property.py
@@ -794,6 +794,11 @@ class BaseProperty(base.BaseObject):
             return
 
         new_value = self._convert_value_input(obj)
+
+        if self._dtype.endswith("-tuple"):
+            t_count = int(self._dtype.split("-")[0])
+            new_value = odml_tuple_import(t_count, new_value)
+
         if len(new_value) > 0 and strict and \
                 dtypes.infer_dtype(new_value[0]) != self.dtype:
 
@@ -830,6 +835,10 @@ class BaseProperty(base.BaseObject):
         new_value = self._convert_value_input(obj)
         if len(new_value) > 1:
             raise ValueError("odml.property.append: Use extend to add a list of values!")
+
+        if self._dtype.endswith("-tuple"):
+            t_count = int(self._dtype.split("-")[0])
+            new_value = odml_tuple_import(t_count, new_value)
 
         if len(new_value) > 0 and strict and \
                 dtypes.infer_dtype(new_value[0]) != self.dtype:

--- a/odml/property.py
+++ b/odml/property.py
@@ -34,19 +34,39 @@ def odml_tuple_import(t_count, new_value):
     except NameError:
         unicode = str
 
-    if len(new_value) != 1 and not isinstance(new_value[0], unicode):
-        return new_value
+    if not isinstance(new_value, (list, tuple)) and \
+            not isinstance(new_value[0], (list, tuple)):
+        new_value = [new_value]
 
-    cln = new_value[0].strip()
-    l_check = cln.startswith("[") and cln.endswith("]")
-    br_check = cln.count("(") == cln.count(")")
-    com_check = cln.count("(") == (cln.count(",") + 1)
-    sep_check = t_count == 1 or cln.count("(") == (cln.count(";") / (t_count - 1))
+    return_value = []
 
-    if l_check and br_check and com_check and sep_check:
-        new_value = cln[1:-1].split(",")
+    for n_val in new_value:
+        if isinstance(n_val, (list, tuple)):
+            if len(n_val) == t_count:
+                n_val_str = "("
+                for tuple_val in n_val:
+                    n_val_str += str(tuple_val) + "; "
+                return_value += [n_val_str[:-2] + ")"]
+        else:
+            #non-unicode handling needed for python2
+            if len(n_val) != 1 and not isinstance(n_val[0], unicode):
+                n_val = n_val.encode('utf-8')
+            cln = n_val.strip()
+            br_check = cln.count("(") == cln.count(")")
+            sep_check = t_count == 1 or cln.count("(") == (cln.count(";") / (t_count - 1))
 
-    return new_value
+            if len(new_value) == 1 and cln.startswith("["):
+                l_check = cln.startswith("[") and cln.endswith("]")
+                com_check = cln.count("(") == (cln.count(",") + 1)
+                if l_check and br_check and com_check and sep_check:
+                    return_value = cln[1:-1].split(",")
+            elif br_check and sep_check:
+                return_value += [cln]
+
+    if not return_value:
+        return_value = new_value
+
+    return return_value
 
 
 @allow_inherit_docstring

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -124,6 +124,16 @@ class TestProperty(unittest.TestCase):
         with self.assertRaises(ValueError):
             Property(name="intprop", dtype=DType.int, value=[2, "Hello!", 4])
 
+        p6 = Property('myprop', values=["(8; 9; 10)", "(11; 12; 13)"], dtype="3-tuple")
+        self.assertEqual(len(p6.values), 2)
+
+        p7 = Property('myprop', values=[["0", "1", "2"], [3, 4, 5]], dtype="3-tuple")
+        self.assertEqual(len(p7.values), 2)
+
+        p7 = Property('myprop', values=["(8; 9; 10)", ["0", "1", "2"], [3, 4, 5]], dtype="3-tuple")
+        self.assertEqual(len(p7.values), 3)
+
+
     def test_value_append(self):
         # Test append w/o Property value or dtype
         prop = Property(name="append")
@@ -227,10 +237,13 @@ class TestProperty(unittest.TestCase):
         self.assertRaises(ValueError, prop8.append, 1.3)
         self.assertRaises(ValueError, prop8.append, True)
 
-        prop9 = Property(name="tuple-test", dtype="3-tuple", values="(1; 2; 3)")
-        prop9.append("(7; 8; 9)")
-        self.assertEqual(len(prop9), 2)
-        self.assertRaises(ValueError, prop9.append, "(10; 11)")
+        prop = Property(name="tuple-test", dtype="3-tuple", values="(1; 2; 3)")
+        prop.append("(7; 8; 9)")
+        self.assertEqual(len(prop), 2)
+        self.assertRaises(ValueError, prop.append, "(10; 11)")
+        prop.append([[2, 3, 4]])
+        self.assertEqual(len(prop), 3)
+        self.assertRaises(ValueError, prop.append, [[10, 11]])
 
     def test_value_extend(self):
         prop = Property(name="extend")
@@ -336,6 +349,9 @@ class TestProperty(unittest.TestCase):
         prop.extend(["(7; 8; 9)", "(10; 11; 12)"])
         self.assertEqual(len(prop), 3)
         self.assertRaises(ValueError, prop.extend, "(10; 11)")
+        prop.extend([[2, 3, 4], [5, 6, 7]])
+        self.assertEqual(len(prop), 5)
+        self.assertRaises(ValueError, prop.extend, [[10, 11]])
 
     def test_get_set_value(self):
         values = [1, 2, 3, 4, 5]

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -124,14 +124,14 @@ class TestProperty(unittest.TestCase):
         with self.assertRaises(ValueError):
             Property(name="intprop", dtype=DType.int, value=[2, "Hello!", 4])
 
-        p6 = Property('myprop', values=["(8; 9; 10)", "(11; 12; 13)"], dtype="3-tuple")
-        self.assertEqual(len(p6.values), 2)
+        prop6 = Property('myprop', values=["(8; 9; 10)", "(11; 12; 13)"], dtype="3-tuple")
+        self.assertEqual(len(prop6.values), 2)
 
-        p7 = Property('myprop', values=[["0", "1", "2"], [3, 4, 5]], dtype="3-tuple")
-        self.assertEqual(len(p7.values), 2)
+        prop7 = Property('myprop', values=[["0", "1", "2"], [3, 4, 5]], dtype="3-tuple")
+        self.assertEqual(len(prop7.values), 2)
 
-        p7 = Property('myprop', values=["(8; 9; 10)", ["0", "1", "2"], [3, 4, 5]], dtype="3-tuple")
-        self.assertEqual(len(p7.values), 3)
+        prop8 = Property('myprop', values=["(8; 9; 10)", ["0", "1", "2"], [3, 4, 5]], dtype="3-tuple")
+        self.assertEqual(len(prop8.values), 3)
 
 
     def test_value_append(self):
@@ -237,13 +237,13 @@ class TestProperty(unittest.TestCase):
         self.assertRaises(ValueError, prop8.append, 1.3)
         self.assertRaises(ValueError, prop8.append, True)
 
-        prop = Property(name="tuple-test", dtype="3-tuple", values="(1; 2; 3)")
-        prop.append("(7; 8; 9)")
-        self.assertEqual(len(prop), 2)
-        self.assertRaises(ValueError, prop.append, "(10; 11)")
-        prop.append([[2, 3, 4]])
-        self.assertEqual(len(prop), 3)
-        self.assertRaises(ValueError, prop.append, [[10, 11]])
+        prop9 = Property(name="tuple-test", dtype="3-tuple", values="(1; 2; 3)")
+        prop9.append("(7; 8; 9)")
+        self.assertEqual(len(prop9), 2)
+        self.assertRaises(ValueError, prop9.append, "(10; 11)")
+        prop9.append([[2, 3, 4]])
+        self.assertEqual(len(prop9), 3)
+        self.assertRaises(ValueError, prop9.append, [[10, 11]])
 
     def test_value_extend(self):
         prop = Property(name="extend")
@@ -345,13 +345,13 @@ class TestProperty(unittest.TestCase):
         self.assertRaises(ValueError, prop3.extend, 1.3)
         self.assertRaises(ValueError, prop3.extend, True)
 
-        prop = Property(name="tuple-test", dtype="3-tuple", values="(1; 2; 3)")
-        prop.extend(["(7; 8; 9)", "(10; 11; 12)"])
-        self.assertEqual(len(prop), 3)
-        self.assertRaises(ValueError, prop.extend, "(10; 11)")
-        prop.extend([[2, 3, 4], [5, 6, 7]])
-        self.assertEqual(len(prop), 5)
-        self.assertRaises(ValueError, prop.extend, [[10, 11]])
+        prop4 = Property(name="tuple-test", dtype="3-tuple", values="(1; 2; 3)")
+        prop4.extend(["(7; 8; 9)", "(10; 11; 12)"])
+        self.assertEqual(len(prop4), 3)
+        self.assertRaises(ValueError, prop4.extend, "(10; 11)")
+        prop4.extend([[2, 3, 4], [5, 6, 7]])
+        self.assertEqual(len(prop4), 5)
+        self.assertRaises(ValueError, prop4.extend, [[10, 11]])
 
     def test_get_set_value(self):
         values = [1, 2, 3, 4, 5]


### PR DESCRIPTION
This PR:

- Allows processing of tuples given as a list instead of a string as well, when setting property values, appending or extending them. Closes #392
- Adds the related tests