### PR TITLE
RDF Subclassing feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ install:
       export PIPCMD=pip;
     fi;
 
-  - $PIPCMD install lxml enum34 pyyaml rdflib
+  - $PIPCMD install lxml enum34 pyyaml rdflib owlrl requests
 
 script:
   - which $PYCMD

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ init:
 build: false
 
 install:
-  - python -m pip install lxml enum34 pyyaml rdflib owlrl
+  - python -m pip install lxml enum34 pyyaml rdflib owlrl requests
 
 test_script:
   - python --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ init:
 build: false
 
 install:
-  - python -m pip install lxml enum34 pyyaml rdflib
+  - python -m pip install lxml enum34 pyyaml rdflib owlrl
 
 test_script:
   - python --version

--- a/odml/tools/rdf_converter.py
+++ b/odml/tools/rdf_converter.py
@@ -5,6 +5,7 @@ the conversion of odML flavored RDF to odML documents.
 
 import os
 import uuid
+import warnings
 
 from io import StringIO
 from rdflib import Graph, Literal, URIRef
@@ -57,19 +58,32 @@ class RDFWriter(object):
     """
     A writer to parse odML files into RDF documents.
 
-    Use the 'rdf_subclassing' flag to disable default usage
-    of Section type conversion to RDF Subclasses.
+    Use the 'rdf_subclassing' flag to disable default usage of Section type conversion to
+    RDF Subclasses.
+    Provide a custom Section type to RDF Subclass Name mapping dictionary via the
+    'custom_subclasses' attribute to add custom or overwrite default RDF Subclass mappings.
 
     Usage:
         RDFWriter(odml_docs).get_rdf_str('turtle')
         RDFWriter(odml_docs).write_file("/output_path", "rdf_format")
+
+        RDFWriter(odml_docs, rdf_subclassing=False).write_file("path", "rdf_format")
+        RDFWriter(odml_docs, custom_subclasses=custom_dict).write_file("path", "rdf_format")
     """
 
-    def __init__(self, odml_documents, rdf_subclassing=True):
+    def __init__(self, odml_documents, rdf_subclassing=True, custom_subclasses=None):
         """
         :param odml_documents: list of odML documents
         :param rdf_subclassing: Flag whether Section types should be converted to RDF Subclasses
                                 for enhanced SPARQL queries. Default is 'True'.
+        :param custom_subclasses: A dict where the keys reference a Section type and the
+                                  corresponding values reference an RDF Class Name. When exporting
+                                  a Section of a type contained in this dict, the resulting RDF
+                                  Instance will be of the corresponding Class and this Class will
+                                  be added as a Subclass of RDF Class "odml:Section" to the
+                                  RDF document.
+                                  Key:value pairs of the "custom_subclasses" dict will overwrite
+                                  existing key:value pairs of the default subclassing dict.
         """
         if not isinstance(odml_documents, list):
             odml_documents = [odml_documents]
@@ -79,8 +93,13 @@ class RDFWriter(object):
         self.graph = Graph()
         self.graph.bind("odml", ODML_NS)
 
-        self.section_subclasses = load_rdf_subclasses()
         self.rdf_subclassing = rdf_subclassing
+
+        self.section_subclasses = load_rdf_subclasses()
+        # If a custom Section type to RDF Subclass dict has been provided,
+        # parse it and update the default section_subclasses dict with the content.
+        if custom_subclasses and isinstance(custom_subclasses, dict):
+            self._parse_custom_subclasses(custom_subclasses)
 
     def convert_to_rdf(self):
         """
@@ -228,24 +247,17 @@ class RDFWriter(object):
         # Add type of current node to the RDF graph
         curr_type = fmt.rdf_type
 
-        print(curr_type)
-
         # Handle section subclass types
         if self.rdf_subclassing:
-            print("I'm in here")
             sub_sec = self._get_section_subclass(sec)
             if sub_sec:
                 curr_type = sub_sec
-
-        print(curr_type)
 
         self.graph.add((curr_node, RDF.type, URIRef(curr_type)))
 
         for k in fmt.rdf_map_keys:
             curr_pred = fmt.rdf_map(k)
             curr_val = getattr(sec, k)
-
-            print("pred: %s; val: %s" % (curr_pred, curr_val))
 
             # Ignore an "id" entry, it has already been used to create the node itself.
             if k == "id" or not curr_val:
@@ -309,6 +321,32 @@ class RDFWriter(object):
             return ODML_NS[self.section_subclasses[sec_type]]
 
         return None
+
+    def _parse_custom_subclasses(self, custom_subclasses):
+        """
+        Parses a provided dictionary of "Section type": "RDF Subclass name"
+        key value pairs and adds the pairs to the parsers' 'section_subclasses'
+        default dictionary. Existing key:value pairs will be overwritten
+        with provided custom key:value pairs and a Warning will be issued.
+        Dictionary values containing whitespaces will raise a ValueError.
+
+        :param custom_subclasses: dictionary of "Section type": "RDF Subclass name" key value pairs.
+                                  Values must not contain whitespaces, a ValueError will be raised
+                                  otherwise.
+        """
+
+        # Do not allow whitespaces in values
+        if " " in "".join(custom_subclasses.values()):
+            msg = "Custom RDF Subclass names must not contain any whitespaces."
+            raise ValueError(msg)
+
+        for k in custom_subclasses:
+            val = custom_subclasses[k]
+            if k in self.section_subclasses:
+                msg = "RDFWriter custom subclasses: Key '%s' already exists. " % k
+                msg += "Value '%s' replaces default value '%s'." % (val, self.section_subclasses[k])
+                warnings.warn(msg, stacklevel=2)
+            self.section_subclasses[k] = val
 
     def __str__(self):
         return self.convert_to_rdf().serialize(format='turtle').decode("utf-8")

--- a/odml/tools/rdf_converter.py
+++ b/odml/tools/rdf_converter.py
@@ -57,14 +57,19 @@ class RDFWriter(object):
     """
     A writer to parse odML files into RDF documents.
 
+    Use the 'rdf_subclassing' flag to disable default usage
+    of Section type conversion to RDF Subclasses.
+
     Usage:
         RDFWriter(odml_docs).get_rdf_str('turtle')
         RDFWriter(odml_docs).write_file("/output_path", "rdf_format")
     """
 
-    def __init__(self, odml_documents):
+    def __init__(self, odml_documents, rdf_subclassing=True):
         """
         :param odml_documents: list of odML documents
+        :param rdf_subclassing: Flag whether Section types should be converted to RDF Subclasses
+                                for enhanced SPARQL queries. Default is 'True'.
         """
         if not isinstance(odml_documents, list):
             odml_documents = [odml_documents]
@@ -75,6 +80,7 @@ class RDFWriter(object):
         self.graph.bind("odml", ODML_NS)
 
         self.section_subclasses = load_rdf_subclasses()
+        self.rdf_subclassing = rdf_subclassing
 
     def convert_to_rdf(self):
         """
@@ -221,15 +227,25 @@ class RDFWriter(object):
 
         # Add type of current node to the RDF graph
         curr_type = fmt.rdf_type
+
+        print(curr_type)
+
         # Handle section subclass types
-        sub_sec = self._get_section_subclass(sec)
-        if sub_sec:
-            curr_type = sub_sec
+        if self.rdf_subclassing:
+            print("I'm in here")
+            sub_sec = self._get_section_subclass(sec)
+            if sub_sec:
+                curr_type = sub_sec
+
+        print(curr_type)
+
         self.graph.add((curr_node, RDF.type, URIRef(curr_type)))
 
         for k in fmt.rdf_map_keys:
             curr_pred = fmt.rdf_map(k)
             curr_val = getattr(sec, k)
+
+            print("pred: %s; val: %s" % (curr_pred, curr_val))
 
             # Ignore an "id" entry, it has already been used to create the node itself.
             if k == "id" or not curr_val:

--- a/odml/tools/rdf_converter.py
+++ b/odml/tools/rdf_converter.py
@@ -10,7 +10,7 @@ import warnings
 from io import StringIO
 from rdflib import Graph, Literal, URIRef
 from rdflib.graph import Seq
-from rdflib.namespace import XSD, RDF
+from rdflib.namespace import XSD, RDF, RDFS
 
 import yaml
 
@@ -252,6 +252,9 @@ class RDFWriter(object):
             sub_sec = self._get_section_subclass(sec)
             if sub_sec:
                 curr_type = sub_sec
+                self.graph.add((URIRef(fmt.rdf_type), RDF.type, RDFS.Class))
+                self.graph.add((URIRef(curr_type), RDF.type, RDFS.Class))
+                self.graph.add((URIRef(curr_type), RDFS.subClassOf, URIRef(fmt.rdf_type)))
 
         self.graph.add((curr_node, RDF.type, URIRef(curr_type)))
 

--- a/odml/tools/rdf_converter.py
+++ b/odml/tools/rdf_converter.py
@@ -4,6 +4,7 @@ the conversion of odML flavored RDF to odML documents.
 """
 
 import os
+import string
 import uuid
 import warnings
 
@@ -338,9 +339,10 @@ class RDFWriter(object):
                                   otherwise.
         """
 
-        # Do not allow whitespaces in values
-        if " " in "".join(custom_subclasses.values()):
-            msg = "Custom RDF Subclass names must not contain any whitespaces."
+        # Do not allow any whitespace characters in values
+        vals = "".join(custom_subclasses.values()).encode()
+        if vals != vals.translate(None, string.whitespace.encode()):
+            msg = "Custom RDF Subclass names must not contain any whitespace characters."
             raise ValueError(msg)
 
         for k in custom_subclasses:

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ packages = [
 with open('README.md') as f:
     description_text = f.read()
 
-install_req = ["lxml", "pyyaml>=5.1", "rdflib", "docopt", "pathlib"]
+install_req = ["lxml", "pyyaml>=5.1", "rdflib", "docopt", "pathlib", "owlrl"]
 
 if sys.version_info < (3, 4):
     install_req += ["enum34"]

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,9 @@ packages = [
 with open('README.md') as f:
     description_text = f.read()
 
-install_req = ["lxml", "pyyaml>=5.1", "rdflib", "docopt", "pathlib", "owlrl"]
+install_req = ["lxml", "pyyaml>=5.1", "rdflib", "docopt", "pathlib"]
+
+tests_req = ["owlrl", "requests"]
 
 if sys.version_info < (3, 4):
     install_req += ["enum34"]
@@ -45,6 +47,7 @@ setup(
     packages=packages,
     test_suite='test',
     install_requires=install_req,
+    tests_require=tests_req,
     include_package_data=True,
     long_description=description_text,
     long_description_content_type="text/markdown",

--- a/test/test_rdf_writer.py
+++ b/test/test_rdf_writer.py
@@ -288,3 +288,25 @@ class TestRDFWriter(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             rdf_writer.get_rdf_str("abc")
+
+    def test_rdf_subclassing_switch(self):
+        """
+        Test the RDF section subclassing switch.
+        """
+        # Section type term defined in odml/resources/section_subclasses.yaml that will
+        # be converted to an RDF Section Subclass of Class "Cell".
+        sub_class_term = "cell"
+
+        # Create minimal document
+        doc = odml.Document()
+        _ = odml.Section(name="test_subclassing", type=sub_class_term, parent=doc)
+
+        # Test default subclassing
+        rdf_writer = RDFWriter([doc])
+        result = rdf_writer.get_rdf_str()
+        self.assertIn("odml:Cell", result)
+
+        # Test inactivation of subclassing feature
+        rdf_writer = RDFWriter([doc], rdf_subclassing=False)
+        result = rdf_writer.get_rdf_str()
+        self.assertNotIn("odml:Cell", result)

--- a/test/test_rdf_writer.py
+++ b/test/test_rdf_writer.py
@@ -310,3 +310,47 @@ class TestRDFWriter(unittest.TestCase):
         rdf_writer = RDFWriter([doc], rdf_subclassing=False)
         result = rdf_writer.get_rdf_str()
         self.assertNotIn("odml:Cell", result)
+
+    def test_rdf_custom_subclasses(self):
+        sub_class_term = "cell"
+
+        # Create minimal document
+        doc = odml.Document()
+        _ = odml.Section(name="test_subclassing", type=sub_class_term, parent=doc)
+
+        # Test None dict
+        rdf_writer = RDFWriter([doc], custom_subclasses=None)
+        self.assertIn("odml:Cell", rdf_writer.get_rdf_str())
+
+        # Test invalid dict
+        rdf_writer = RDFWriter([doc], custom_subclasses=["invalid"])
+        self.assertIn("odml:Cell", rdf_writer.get_rdf_str())
+
+        # Test value whitespace
+        invalid_dict = {"type_1": "Class 1", "type_2": "Class 2"}
+        with self.assertRaises(ValueError):
+            _ = RDFWriter([doc], custom_subclasses=invalid_dict)
+
+        # Test custom subclassing
+        type_custom_class = "species"
+        custom_class_dict = {type_custom_class: "Species"}
+
+        doc = odml.Document()
+        _ = odml.Section(name="test_subclassing", type="cell", parent=doc)
+        _ = odml.Section(name="test_custom_subclassing", type=type_custom_class, parent=doc)
+
+        rdf_writer = RDFWriter([doc], custom_subclasses=custom_class_dict)
+        self.assertIn("odml:Cell", rdf_writer.get_rdf_str())
+        self.assertIn("odml:Species", rdf_writer.get_rdf_str())
+
+        # Test custom subclassing overwrite
+        sub_class_type = "cell"
+        custom_class_dict = {sub_class_type: "Neuron"}
+
+        doc = odml.Document()
+        _ = odml.Section(name="test_subclassing", type=sub_class_type, parent=doc)
+
+        with self.assertWarns(UserWarning):
+            rdf_writer = RDFWriter([doc], custom_subclasses=custom_class_dict)
+            self.assertNotIn("odml:Cell", rdf_writer.get_rdf_str())
+            self.assertIn("odml:Neuron", rdf_writer.get_rdf_str())

--- a/test/test_rdf_writer.py
+++ b/test/test_rdf_writer.py
@@ -338,7 +338,11 @@ class TestRDFWriter(unittest.TestCase):
         self.assertIn("odml:Cell", rdf_writer.get_rdf_str())
 
         # Test value whitespace
-        invalid_dict = {"type_1": "Class 1", "type_2": "Class 2"}
+        inval_a = "This should"
+        inval_b = "fail\nin"
+        inval_c = "the\tmost"
+        inval_d = "complete\rway"
+        invalid_dict = {"type_1": inval_a, "type_2": inval_b, "type_3": inval_c, "type_4": inval_d}
         with self.assertRaises(ValueError):
             _ = RDFWriter([doc], custom_subclasses=invalid_dict)
 


### PR DESCRIPTION
This PR closes issue #397 and its sub-issues #394, #395 and #396.

RDF subclasses are now properly added by default to any written RDF document. The RDF document will now also include RDF Subclass definitions in addition to the actual data (see issue #396) to enable Subclass specific queries.
- The RDFWriter features an `rdf_subclass` attribute, to disable subclassing (see issue #394).
- The RDFWriter features a `custom_subclasses` attribute to provide additional subclass mappings in addition to the default one (see issue #395).