### PR TITLE
Dropping Python 2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ matrix:
 
   include:
     - os: linux
-      python: "2.7"
-    - os: linux
       python: "3.5"
     - os: linux
       python: "3.6"
@@ -27,10 +25,6 @@ matrix:
       python: "3.9-dev"
       dist: bionic
 
-    - os: osx
-      language: generic
-      env:
-        - OSXENV=2.7.14
     - os: osx
       language: generic
       env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 Used to document all changes from previous releases and collect changes 
 until the next release.
 
+# Latest
+
+# Dropping Python 2 support
+
+Python 2 has reached end of life. The codebase has been cleaned from Python 2 and Python 3 compatible code, all tests now run exclusively on Python 3 versions.
+
+# Features
+- `odml.save` and `odmlparser.ODMLWriter` now support additional keywords. See issue #402 and PR #403 for details.
+
+
 # Version 1.5.1
 
 # RDF Subclassing feature

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,6 @@ image: Visual Studio 2017
 
 environment:
   matrix:
-    - PYTHON: "C:\\Python27"
-      PYVER: 2
-      BITS: 32
     - PYTHON: "C:\\Python36"
       PYVER: 3
       BITS: 32
@@ -16,9 +13,6 @@ environment:
     - PYTHON: "C:\\Python38"
       PYVER: 3
       BITS: 32
-    - PYTHON: "C:\\Python27-x64"
-      PYVER: 2
-      BITS: 64
     - PYTHON: "C:\\Python36-x64"
       PYVER: 3
       BITS: 64

--- a/odml/dtypes.py
+++ b/odml/dtypes.py
@@ -10,11 +10,6 @@ from enum import Enum
 
 self = sys.modules[__name__].__dict__
 
-try:
-    unicode = unicode
-except NameError:
-    unicode = str
-
 FORMAT_DATE = "%Y-%m-%d"
 FORMAT_DATETIME = "%Y-%m-%d %H:%M:%S"
 FORMAT_TIME = "%H:%M:%S"
@@ -103,7 +98,7 @@ def valid_type(dtype):
     if dtype is None:
         return True
 
-    if not isinstance(dtype, str) and not isinstance(dtype, unicode):
+    if not isinstance(dtype, str):
         return False
 
     dtype = dtype.lower()
@@ -158,7 +153,7 @@ def set(value, dtype=None):
         if isinstance(value, str):
             return str_set(value)
     else:
-        if isinstance(value, (str, unicode)):
+        if isinstance(value, str):
             return str_set(value)
     return self.get(dtype + "_set", str_set)(value)
 
@@ -205,9 +200,6 @@ def str_get(string):
     # Do not stringify empty list or dict but make sure boolean False gets through.
     if string in [None, "", [], {}]:
         return default_values("string")
-
-    if sys.version_info < (3, 0):
-        return unicode(string)
 
     return str(string)
 
@@ -296,7 +288,7 @@ def boolean_get(string):
     if string in [None, "", [], {}]:
         return default_values("boolean")
 
-    if isinstance(string, (unicode, str)):
+    if isinstance(string, str):
         string = string.lower()
 
     truth = ["true", "1", True, "t"]  # be kind, spec only accepts True / False

--- a/odml/dtypes.py
+++ b/odml/dtypes.py
@@ -147,14 +147,13 @@ def set(value, dtype=None):
     """
     if not dtype:
         return str_set(value)
+
     if dtype.endswith("-tuple"):
         return tuple_set(value)
-    if sys.version_info > (3, 0):
-        if isinstance(value, str):
-            return str_set(value)
-    else:
-        if isinstance(value, str):
-            return str_set(value)
+
+    if isinstance(value, str):
+        return str_set(value)
+
     return self.get(dtype + "_set", str_set)(value)
 
 

--- a/odml/format.py
+++ b/odml/format.py
@@ -3,8 +3,6 @@ The module provides general format information and mappings of
 XML and RDF attributes to their Python class equivalents.
 """
 
-import sys
-
 from rdflib import Namespace
 
 import odml
@@ -76,12 +74,8 @@ class Format(object):
         if self._rev_map is None:
             # create the reverse map only if requested
             self._rev_map = {}
-            if sys.version_info < (3, 0):
-                for k, val in self._map.iteritems():
-                    self._rev_map[val] = k
-            else:
-                for k, val in self._map.items():
-                    self._rev_map[val] = k
+            for k, val in self._map.items():
+                self._rev_map[val] = k
 
         return self._rev_map.get(name)
 

--- a/odml/property.py
+++ b/odml/property.py
@@ -43,9 +43,6 @@ def odml_tuple_import(t_count, new_value):
                     n_val_str += str(tuple_val) + "; "
                 return_value += [n_val_str[:-2] + ")"]
         else:
-            # non-unicode handling needed for python2
-            # if len(n_val) != 1 and not isinstance(n_val[0], unicode):
-            #    n_val = n_val.encode('utf-8')
             cln = n_val.strip()
             br_check = cln.count("(") == cln.count(")")
             sep_check = t_count == 1 or cln.count("(") == (cln.count(";") / (t_count - 1))

--- a/odml/property.py
+++ b/odml/property.py
@@ -29,11 +29,6 @@ def odml_tuple_import(t_count, new_value):
     :param new_value: string containing an odml style tuple list.
     :return: list of odml style tuples.
     """
-    try:
-        unicode = unicode
-    except NameError:
-        unicode = str
-
     if not isinstance(new_value, (list, tuple)) and \
             not isinstance(new_value[0], (list, tuple)):
         new_value = [new_value]
@@ -48,9 +43,9 @@ def odml_tuple_import(t_count, new_value):
                     n_val_str += str(tuple_val) + "; "
                 return_value += [n_val_str[:-2] + ")"]
         else:
-            #non-unicode handling needed for python2
-            if len(n_val) != 1 and not isinstance(n_val[0], unicode):
-                n_val = n_val.encode('utf-8')
+            # non-unicode handling needed for python2
+            # if len(n_val) != 1 and not isinstance(n_val[0], unicode):
+            #    n_val = n_val.encode('utf-8')
             cln = n_val.strip()
             br_check = cln.count("(") == cln.count(")")
             sep_check = t_count == 1 or cln.count("(") == (cln.count(";") / (t_count - 1))

--- a/odml/scripts/odml_convert.py
+++ b/odml/scripts/odml_convert.py
@@ -37,11 +37,6 @@ import odml
 
 from odml.tools.converters import VersionConverter as VerConf
 
-try:
-    unicode = unicode
-except NameError:
-    unicode = str
-
 
 def run_conversion(file_list, output_dir, report, source_format="XML"):
     """
@@ -56,7 +51,7 @@ def run_conversion(file_list, output_dir, report, source_format="XML"):
     # Exceptions are kept as broad as possible to ignore any non-odML or
     # invalid odML files and ensuring everything that can be will be converted.
     for curr_file in file_list:
-        file_path = unicode(curr_file.absolute())
+        file_path = str(curr_file.absolute())
         report.write("[Info] Handling file '%s'\n" % file_path)
         # When loading the current file succeeds, it is
         # a recent odML format file and can be ignored.

--- a/odml/scripts/odml_to_rdf.py
+++ b/odml/scripts/odml_to_rdf.py
@@ -39,11 +39,6 @@ import odml
 from odml.tools.odmlparser import ODMLReader, ODMLWriter
 from odml.tools.converters import VersionConverter as VerConf
 
-try:
-    unicode = unicode
-except NameError:
-    unicode = str
-
 
 def run_rdf_export(odml_file, export_dir):
     """
@@ -75,7 +70,7 @@ def run_conversion(file_list, output_dir, rdf_dir, report, source_format="XML"):
     # Exceptions are kept as broad as possible to ignore any non-odML or
     # invalid odML files and ensuring everything that can be will be converted.
     for curr_file in file_list:
-        file_path = unicode(curr_file.absolute())
+        file_path = str(curr_file.absolute())
         report.write("[Info] Handling file '%s'\n" % file_path)
         # When loading the current file succeeds, it is
         # a recent odML format file and can be exported

--- a/odml/templates.py
+++ b/odml/templates.py
@@ -3,7 +3,6 @@ Handles (deferred) loading of odML templates
 """
 
 import os
-import sys
 import tempfile
 import threading
 try:
@@ -65,8 +64,7 @@ def cache_load(url):
             dati.fromtimestamp(os.path.getmtime(cache_file)) < (dati.now() - CACHE_AGE):
         try:
             data = urllib2.urlopen(url).read()
-            if sys.version_info.major > 2:
-                data = data.decode("utf-8")
+            data = data.decode("utf-8")
         except (ValueError, URLError) as exc:
             msg = "Failed to load resource from '%s': %s" % (url, exc)
             exc.args = (msg,)  # needs to be a tuple

--- a/odml/terminology.py
+++ b/odml/terminology.py
@@ -4,7 +4,6 @@ Handles (deferred) loading of terminology data and access to it for odML documen
 
 import datetime
 import os
-import sys
 import tempfile
 import threading
 try:
@@ -47,8 +46,7 @@ def cache_load(url, replace_file=False):
             datetime.datetime.now() - CACHE_AGE:
         try:
             data = urllib2.urlopen(url).read()
-            if sys.version_info.major > 2:
-                data = data.decode("utf-8")
+            data = data.decode("utf-8")
         except Exception as exc:
             print("failed loading '%s': %s" % (url, exc))
             return

--- a/odml/tools/converters/format_converter.py
+++ b/odml/tools/converters/format_converter.py
@@ -33,11 +33,6 @@ from .. import RDFWriter
 from . import VersionConverter
 from ..parser_utils import RDF_CONVERSION_FORMATS
 
-try:
-    unicode = unicode
-except NameError:
-    unicode = str
-
 
 CONVERSION_FORMATS = copy.deepcopy(RDF_CONVERSION_FORMATS)
 CONVERSION_FORMATS.update({

--- a/odml/tools/converters/version_converter.py
+++ b/odml/tools/converters/version_converter.py
@@ -518,8 +518,6 @@ class VersionConverter(object):
         :param backend: Format of the source file, default is XML.
         """
         data = self.convert(backend)
-        if sys.version_info < (3,):
-            data = data.encode('utf-8')
 
         ext = [".xml", ".odml"]
         if not filename.endswith(tuple(ext)):

--- a/odml/tools/converters/version_converter.py
+++ b/odml/tools/converters/version_converter.py
@@ -19,11 +19,6 @@ from ...format import Document, Section, Property
 from ...info import FORMAT_VERSION
 from ...terminology import Terminologies, REPOSITORY_BASE
 
-try:
-    unicode = unicode
-except NameError:
-    unicode = str
-
 
 class VersionConverter(object):
     """

--- a/odml/tools/converters/version_converter.py
+++ b/odml/tools/converters/version_converter.py
@@ -6,7 +6,6 @@ odML XML files from version 1.0 to 1.1.
 import io
 import json
 import os
-import sys
 import uuid
 import yaml
 

--- a/odml/tools/odmlparser.py
+++ b/odml/tools/odmlparser.py
@@ -21,11 +21,6 @@ from .parser_utils import SUPPORTED_PARSERS
 from .rdf_converter import RDFReader, RDFWriter
 from ..validation import Validation
 
-try:
-    unicode = unicode
-except NameError:
-    unicode = str
-
 
 class ODMLWriter:
     """
@@ -108,7 +103,9 @@ class ODMLWriter:
         """
         string_doc = ''
 
-        if self.parser == "RDF":
+        if self.parser == 'XML':
+            string_doc = str(xmlparser.XMLWriter(odml_document))
+        elif self.parser == "RDF":
             rdf_format = "xml"
             if "rdf_format" in kwargs and isinstance(kwargs["rdf_format"], str):
                 rdf_format = kwargs["rdf_format"]

--- a/odml/tools/odmlparser.py
+++ b/odml/tools/odmlparser.py
@@ -124,9 +124,6 @@ class ODMLWriter:
                 string_doc = json.dumps(odml_output, indent=4,
                                         cls=JSONDateTimeSerializer)
 
-        if sys.version_info.major < 3:
-            string_doc = string_doc.encode("utf-8")
-
         return string_doc
 
 

--- a/odml/tools/odmlparser.py
+++ b/odml/tools/odmlparser.py
@@ -6,7 +6,6 @@ All supported formats can be found in parser_utils.SUPPORTED_PARSERS.
 
 import datetime
 import json
-import sys
 import warnings
 
 from os.path import basename

--- a/odml/tools/rdf_converter.py
+++ b/odml/tools/rdf_converter.py
@@ -22,11 +22,6 @@ from ..info import FORMAT_VERSION, INSTALL_PATH
 from .dict_parser import DictReader
 from .parser_utils import ParserException, RDF_CONVERSION_FORMATS
 
-try:
-    unicode = unicode
-except NameError:
-    unicode = str
-
 ODML_NS = Format.namespace()
 
 
@@ -129,7 +124,7 @@ class RDFWriter(object):
                               to the current parent node.
         :param values: list of odml values.
         """
-        seq = URIRef(ODML_NS + unicode(uuid.uuid4()))
+        seq = URIRef(ODML_NS + str(uuid.uuid4()))
         self.graph.add((seq, RDF.type, RDF.Seq))
         self.graph.add((parent_node, rdf_predicate, seq))
 
@@ -138,14 +133,14 @@ class RDFWriter(object):
         # Once rdflib upgrades this should be reversed to RDF:li again!
         # see https://github.com/RDFLib/rdflib/issues/280
         # -- keep until supported
-        # bag = URIRef(ODML_NS + unicode(uuid.uuid4()))
+        # bag = URIRef(ODML_NS + str(uuid.uuid4()))
         # self.graph.add((bag, RDF.type, RDF.Bag))
         # self.graph.add((curr_node, fmt.rdf_map(k), bag))
         # for curr_val in values:
         #     self.graph.add((bag, RDF.li, Literal(curr_val)))
         counter = 1
         for curr_val in values:
-            custom_predicate = "%s_%s" % (unicode(RDF), counter)
+            custom_predicate = "%s_%s" % (str(RDF), counter)
             self.graph.add((seq, URIRef(custom_predicate), Literal(curr_val)))
             counter = counter + 1
 
@@ -160,7 +155,7 @@ class RDFWriter(object):
         :param odml_list: list of odml entities.
         """
         for curr_item in odml_list:
-            node = URIRef(ODML_NS + unicode(curr_item.id))
+            node = URIRef(ODML_NS + str(curr_item.id))
             self.graph.add((parent_node, rdf_predicate, node))
 
             fmt = curr_item.format()
@@ -185,7 +180,7 @@ class RDFWriter(object):
         if not terminology_node:
             # adding terminology url value to the graph and linking it
             # to the current RDF node.
-            terminology_node = URIRef(ODML_NS + unicode(uuid.uuid4()))
+            terminology_node = URIRef(ODML_NS + str(uuid.uuid4()))
             self.graph.add((terminology_node, RDF.type, URIRef(leaf_value)))
             self.graph.add((self.hub_root, ODML_NS.hasTerminology, terminology_node))
 
@@ -203,7 +198,7 @@ class RDFWriter(object):
         fmt = doc.format()
 
         if not curr_node:
-            curr_node = URIRef(ODML_NS + unicode(doc.id))
+            curr_node = URIRef(ODML_NS + str(doc.id))
 
         self.graph.add((curr_node, RDF.type, URIRef(fmt.rdf_type)))
         self.graph.add((self.hub_root, ODML_NS.hasDocument, curr_node))
@@ -478,7 +473,7 @@ class RDFReader(object):
             elif attr[0] == "id":
                 doc_attrs[attr[0]] = doc_uri.split("#", 1)[1]
             elif elems:
-                doc_attrs[attr[0]] = unicode(elems[0].toPython())
+                doc_attrs[attr[0]] = str(elems[0].toPython())
 
         return {'Document': doc_attrs, 'odml-version': FORMAT_VERSION}
 
@@ -503,7 +498,7 @@ class RDFReader(object):
             elif attr[0] == "id":
                 sec_attrs[attr[0]] = sec_uri.split("#", 1)[1]
             elif elems:
-                sec_attrs[attr[0]] = unicode(elems[0].toPython())
+                sec_attrs[attr[0]] = str(elems[0].toPython())
 
         self._check_mandatory_attrs(sec_attrs)
         return sec_attrs
@@ -537,7 +532,7 @@ class RDFReader(object):
             elif attr[0] == "id":
                 prop_attrs[attr[0]] = prop_uri.split("#", 1)[1]
             elif elems:
-                prop_attrs[attr[0]] = unicode(elems[0].toPython())
+                prop_attrs[attr[0]] = str(elems[0].toPython())
 
         self._check_mandatory_attrs(prop_attrs)
         return prop_attrs

--- a/odml/tools/xmlparser.py
+++ b/odml/tools/xmlparser.py
@@ -24,11 +24,6 @@ from .. import format as ofmt
 from ..info import FORMAT_VERSION
 from .parser_utils import InvalidVersionException, ParserException, odml_tuple_export
 
-try:
-    unicode = unicode
-except NameError:
-    unicode = str
-
 
 XML_HEADER = """<?xml version="1.0" encoding="UTF-8"?>"""
 EXTERNAL_STYLE_HEADER = """<?xml-stylesheet  type="text/xsl" href="odmlDocument.xsl"?>"""
@@ -86,7 +81,7 @@ def to_csv(val):
     """
     # Make sure all individual values do not contain
     # leading or trailing whitespaces.
-    unicode_values = list(map(unicode.strip, map(unicode, val)))
+    unicode_values = list(map(str.strip, map(str, val)))
     stream = StringIO()
     writer = csv.writer(stream, dialect="excel")
     writer.writerow(unicode_values)
@@ -172,10 +167,7 @@ class XMLWriter:
                         ele = XMLWriter.save_element(curr_val)
                         cur.append(ele)
                 else:
-                    if sys.version_info < (3,):
-                        ele = E(k, unicode(val))
-                    else:
-                        ele = E(k, str(val))
+                    ele = E(k, str(val))
                     cur.append(ele)
         return cur
 
@@ -205,10 +197,7 @@ class XMLWriter:
                                 tag: '<xsl:template match="odML">[custom]</xsl:template>'.
         """
         # calculate the data before opening the file in case we get any exception
-        if sys.version_info < (3,):
-            data = unicode(self).encode('utf-8')
-        else:
-            data = str(self)
+        data = str(self)
 
         with open(filename, "w") as file:
             file.write("%s\n" % XML_HEADER)
@@ -306,7 +295,7 @@ class XMLReader(object):
         doc = self.parse_element(root)
 
         # Provide original file name via the in memory document
-        if isinstance(xml_file, unicode):
+        if isinstance(xml_file, str):
             doc.origin_file_name = basename(xml_file)
 
         return doc

--- a/odml/tools/xmlparser.py
+++ b/odml/tools/xmlparser.py
@@ -449,11 +449,7 @@ class XMLReader(object):
                 self.error("Invalid element <%s> in odML document section <%s> "
                            % (node.tag, root.tag), node)
 
-        if sys.version_info > (3,):
-            check_args = dict(list(arguments.items()) + list(extra_args.items()))
-        else:
-            check_args = dict(arguments.items() + extra_args.items())
-
+        check_args = dict(list(arguments.items()) + list(extra_args.items()))
         self.check_mandatory_arguments(check_args, fmt, root.tag, root)
 
         # Instantiate the current odML object with the parsed attributes.

--- a/odml/validation.py
+++ b/odml/validation.py
@@ -9,11 +9,6 @@ from enum import Enum
 
 from . import dtypes
 
-try:
-    unicode = unicode
-except NameError:
-    unicode = str
-
 LABEL_ERROR = 'error'
 LABEL_WARNING = 'warning'
 
@@ -92,7 +87,7 @@ class ValidationError(object):
 
     def __repr__(self):
         # Cleanup the odml object print strings
-        print_str = unicode(self.obj).split()[0].split("[")[0].split(":")[0]
+        print_str = str(self.obj).split()[0].split("[")[0].split(":")[0]
         # Document has no name attribute and should not print id or name info
         if hasattr(self.obj, "name"):
             if self.obj.name and self.obj.name != self.obj.id:

--- a/test/test_dtypes.py
+++ b/test/test_dtypes.py
@@ -1,24 +1,10 @@
 import datetime
 import unittest
 
-from sys import version_info
-
 import odml.dtypes as typ
 
 
 class TestTypes(unittest.TestCase):
-
-    def assert_local_regexp(self, text, regular_expression):
-        """
-        Python 2 is dead and assertRegexpMatches is deprecated and
-        will be removed, but keep compatibility until py 2 support is
-        fully dropped.
-        """
-
-        if version_info.major < 3:
-            self.assertRegexpMatches(text, regular_expression)
-        else:
-            self.assertRegex(text, regular_expression)
 
     def test_valid_type(self):
         # Test None
@@ -47,8 +33,8 @@ class TestTypes(unittest.TestCase):
         self.assertIsInstance(typ.date_get(""), datetime.date)
 
         reg = "^[0-9]{4}-(0[1-9]|1[0-2])-([0-2][0-9]|3[0-1])$"
-        self.assert_local_regexp(typ.date_get(None).strftime(typ.FORMAT_DATE), reg)
-        self.assert_local_regexp(typ.date_get("").strftime(typ.FORMAT_DATE), reg)
+        self.assertRegex(typ.date_get(None).strftime(typ.FORMAT_DATE), reg)
+        self.assertRegex(typ.date_get("").strftime(typ.FORMAT_DATE), reg)
 
         date = datetime.date(2011, 12, 1)
         date_string = '2011-12-01'
@@ -79,8 +65,8 @@ class TestTypes(unittest.TestCase):
         self.assertIsInstance(typ.time_get(""), datetime.time)
 
         reg = "^[0-5][0-9]:[0-5][0-9]:[0-5][0-9]$"
-        self.assert_local_regexp(typ.time_get(None).strftime(typ.FORMAT_TIME), reg)
-        self.assert_local_regexp(typ.time_get("").strftime(typ.FORMAT_TIME), reg)
+        self.assertRegex(typ.time_get(None).strftime(typ.FORMAT_TIME), reg)
+        self.assertRegex(typ.time_get("").strftime(typ.FORMAT_TIME), reg)
 
         time = datetime.time(12, 34, 56)
         time_string = '12:34:56'
@@ -111,8 +97,8 @@ class TestTypes(unittest.TestCase):
         self.assertIsInstance(typ.datetime_get(""), datetime.datetime)
 
         reg = "^[0-9]{4}-(0[1-9]|1[0-2])-([0-2][0-9]|3[0-1]) [0-5][0-9]:[0-5][0-9]:[0-5][0-9]$"
-        self.assert_local_regexp(typ.datetime_get(None).strftime(typ.FORMAT_DATETIME), reg)
-        self.assert_local_regexp(typ.datetime_get("").strftime(typ.FORMAT_DATETIME), reg)
+        self.assertRegex(typ.datetime_get(None).strftime(typ.FORMAT_DATETIME), reg)
+        self.assertRegex(typ.datetime_get("").strftime(typ.FORMAT_DATETIME), reg)
 
         date = datetime.datetime(2011, 12, 1, 12, 34, 56)
         date_string = '2011-12-01 12:34:56'

--- a/test/test_infer_type.py
+++ b/test/test_infer_type.py
@@ -5,23 +5,18 @@ from datetime import datetime as dt, date, time
 from odml import Property, Section, Document
 from odml.tools.xmlparser import XMLReader, XMLWriter
 
-try:
-    unicode = unicode
-except NameError:
-    unicode = str
-
 
 class TestInferType(unittest.TestCase):
 
     def test_string(self):
         prop = Property("test", value="some_string")
         self.assertEqual(prop.dtype, "string")
-        self.assertIsInstance(prop.values[0], unicode)
+        self.assertIsInstance(prop.values[0], str)
 
     def test_text(self):
         prop = Property("test", value="some\nstring")
         self.assertEqual(prop.dtype, "text")
-        self.assertIsInstance(prop.values[0], unicode)
+        self.assertIsInstance(prop.values[0], str)
 
     def test_int(self):
         prop = Property("test", value=111)
@@ -70,18 +65,18 @@ class TestInferType(unittest.TestCase):
         sec.append(Property("timeprop", dt.now().time()))
         sec.append(Property("boolprop", True))
 
-        str_doc = unicode(XMLWriter(doc))
+        str_doc = str(XMLWriter(doc))
 
         new_doc = XMLReader().from_string(str_doc)
         new_sec = new_doc.sections[0]
 
         prop = new_sec.properties["strprop"]
         self.assertEqual(prop.dtype, "string")
-        self.assertIsInstance(prop.values[0], unicode)
+        self.assertIsInstance(prop.values[0], str)
 
         prop = new_sec.properties["txtprop"]
         self.assertEqual(prop.dtype, "text")
-        self.assertIsInstance(prop.values[0], unicode)
+        self.assertIsInstance(prop.values[0], str)
 
         prop = new_sec.properties["intprop"]
         self.assertEqual(prop.dtype, "int")

--- a/test/test_samplefile.py
+++ b/test/test_samplefile.py
@@ -14,20 +14,12 @@ from odml.info import FORMAT_VERSION
 from odml.tools import xmlparser
 from .util import create_test_dir
 
-try:
-    unicode = unicode
-except NameError:
-    unicode = str
-
 
 def dump(doc, filename):
     """
     Helper function to dump a document for debugging purposes
     """
-    if sys.version_info < (3, 0):
-        odml_string = unicode(xmlparser.XMLWriter(doc))
-    else:
-        odml_string = str(xmlparser.XMLWriter(doc))
+    odml_string = str(xmlparser.XMLWriter(doc))
     open(filename, "w").write(odml_string)
 
 
@@ -150,10 +142,7 @@ class SampleFileOperationTest(unittest.TestCase):
 
     def test_xml_writer_version(self):
         doc = odml.Document()
-        if sys.version_info < (3, 0):
-            val = unicode(xmlparser.XMLWriter(doc))
-        else:
-            val = str(xmlparser.XMLWriter(doc))
+        val = str(xmlparser.XMLWriter(doc))
 
         self.assertIn('version="%s"' % FORMAT_VERSION, val)
         doc = xmlparser.XMLReader().from_string(val)
@@ -174,7 +163,7 @@ class SampleFileOperationTest(unittest.TestCase):
 
         for Writer, Reader in modules:
             doc = Writer(self.doc)
-            doc = StringIO(unicode(doc))
+            doc = StringIO(str(doc))
             doc = Reader().from_file(doc)
             self.assertEqual(doc, self.doc)
 

--- a/test/test_version_converter.py
+++ b/test/test_version_converter.py
@@ -11,11 +11,6 @@ from odml.terminology import REPOSITORY_BASE
 from odml.tools.converters import VersionConverter
 from .util import ODML_CACHE_DIR as CACHE_DIR, create_test_dir, TEST_RESOURCES_DIR as RES_DIR
 
-try:
-    unicode = unicode
-except NameError:
-    unicode = str
-
 
 class TestVersionConverter(unittest.TestCase):
     def setUp(self):
@@ -119,7 +114,7 @@ class TestVersionConverter(unittest.TestCase):
         self.assertEqual(prop.find("unit"), None)
         self.assertEqual(prop.find("type"), None)
 
-        file = io.StringIO(unicode(self.doc))
+        file = io.StringIO(str(self.doc))
         converter = self.VC(file)
         tree = converter._convert(converter._parse_xml())
         root = tree.getroot()
@@ -182,7 +177,7 @@ class TestVersionConverter(unittest.TestCase):
                 </odML>
         """ % local_old_url
 
-        file = io.StringIO(unicode(doc))
+        file = io.StringIO(str(doc))
         converter = self.VC(file)
         conv_doc = converter._convert(converter._parse_xml())
         root = conv_doc.getroot()
@@ -198,7 +193,7 @@ class TestVersionConverter(unittest.TestCase):
         self.assertEqual(len(root.findall("value")), 0)
 
         # Test warning message on non-importable repository
-        file = io.StringIO(unicode(invalid_repo_doc))
+        file = io.StringIO(str(invalid_repo_doc))
         converter = self.VC(file)
         conv_doc = converter._convert(converter._parse_xml())
         root = conv_doc.getroot()
@@ -206,7 +201,7 @@ class TestVersionConverter(unittest.TestCase):
         self.assertIn("not odML v1.1 compatible", converter.conversion_log[0])
 
         # Test warning message on old repository
-        file = io.StringIO(unicode(old_repo_doc))
+        file = io.StringIO(str(old_repo_doc))
         converter = self.VC(file)
         conv_doc = converter._convert(converter._parse_xml())
         root = conv_doc.getroot()
@@ -261,7 +256,7 @@ class TestVersionConverter(unittest.TestCase):
                 </odML>
         """ % (local_url, local_url)
 
-        file = io.StringIO(unicode(doc))
+        file = io.StringIO(str(doc))
         converter = self.VC(file)
         conv_doc = converter._convert(converter._parse_xml())
         root = conv_doc.getroot()
@@ -311,7 +306,7 @@ class TestVersionConverter(unittest.TestCase):
                   </section>
                 </odML>""" % local_old_url
 
-        file = io.StringIO(unicode(doc))
+        file = io.StringIO(str(doc))
         converter = self.VC(file)
         conv_doc = converter._convert(converter._parse_xml())
         sec = conv_doc.getroot().findall("section")
@@ -327,7 +322,7 @@ class TestVersionConverter(unittest.TestCase):
                   </section>
                 </odML>""" % local_old_url
 
-        file = io.StringIO(unicode(doc))
+        file = io.StringIO(str(doc))
         converter = self.VC(file)
         conv_doc = converter._convert(converter._parse_xml())
         sec = conv_doc.getroot().findall("section")
@@ -368,7 +363,7 @@ class TestVersionConverter(unittest.TestCase):
                 </odML>
         """
 
-        file = io.StringIO(unicode(doc))
+        file = io.StringIO(str(doc))
         converter = self.VC(file)
         conv_doc = converter._convert(converter._parse_xml())
         root = conv_doc.getroot()
@@ -533,7 +528,7 @@ class TestVersionConverter(unittest.TestCase):
                 </odML>
         """
 
-        file = io.StringIO(unicode(doc))
+        file = io.StringIO(str(doc))
         converter = self.VC(file)
         conv_doc = converter._convert(converter._parse_xml())
         root = conv_doc.getroot()


### PR DESCRIPTION
Python 2 has reached end of life

- the codebase has been cleaned from Python 2 and Python 3 compatible code.
- all tests now run exclusively on Python 3 versions.
