### PR TITLE
Force xml writer to use utf-8 encoding on all operating systems

### DIFF
--- a/odml/tools/xmlparser.py
+++ b/odml/tools/xmlparser.py
@@ -199,7 +199,7 @@ class XMLWriter:
         # calculate the data before opening the file in case we get any exception
         data = str(self)
 
-        with open(filename, "w") as file:
+        with open(filename, "w", encoding = "utf-8") as file:
             file.write("%s\n" % XML_HEADER)
             if not local_style and not custom_template:
                 file.write("%s\n" % EXTERNAL_STYLE_HEADER)

--- a/test/test_xml_writer.py
+++ b/test/test_xml_writer.py
@@ -20,7 +20,7 @@ class TestXMLWriter(unittest.TestCase):
 
         doc = odml.Document()
         sec = doc.create_section(name="sec", type="test")
-        _ = sec.create_property(name="prop", value=['a', 'b', 'c'])
+        _ = sec.create_property(name="prop", value=['a', 'b', 'c', 'μ'])
 
         self.doc = doc
         self.writer = XMLWriter(doc)


### PR DESCRIPTION
Python encodes with cp1252 per default on Windows, resulting in invalid xml files. As the xml header always states that utf-8 is used, I actually enforced it when opening the file for writing. This fixes problems with parsing the written xml files under Windows operating systems.