### PR TITLE
Introducing github actions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,33 @@
+name: run-tests
+on:
+  # test cron by running it once a day at 01:00
+  schedule:
+  - cron:  '0 1 * * *'
+  push:
+    branches:
+      - master
+      - dev
+  pull_request:
+    branches:
+      - master
+jobs:
+  tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.6]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+      - name: Install dependencies
+        run: |
+          python setup.py install
+          pip install owlrl requests pytest
+      - name: Run tests
+        run: pytest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,6 +28,6 @@ jobs:
       - name: Install dependencies
         run: |
           python setup.py install
-          pip install owlrl requests pytest
+          pip install -r requirements-test.txt
       - name: Run tests
         run: pytest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Install dependencies
         run: |
           python setup.py install
+          pip install -r requirements-test.txt
           pip install pytest coveralls
       - name: Create coverage
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        python-version: [3.6]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,3 +31,24 @@ jobs:
           pip install -r requirements-test.txt
       - name: Run tests
         run: pytest
+  run-coverall:
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+      - name: Install dependencies
+        run: |
+          python setup.py install
+          pip install pytest coveralls
+      - name: Create coverage
+        run: |
+          coverage run --source=bren -m pytest test/ --ignore test/test_dependencies.py
+      - name: Submit to coveralls
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: coveralls --service=github

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -47,7 +47,7 @@ jobs:
           pip install pytest coveralls
       - name: Create coverage
         run: |
-          coverage run --source=bren -m pytest test/ --ignore test/test_dependencies.py
+          coverage run --source=odml -m pytest test/
       - name: Submit to coveralls
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,26 +4,10 @@ dist: trusty
 language: python
 
 matrix:
-  allow_failures:
-    - os: linux
-      python: "3.9-dev"
-      dist: bionic
-
   include:
-    - os: linux
-      python: "3.5"
-    - os: linux
-      python: "3.6"
-      env: COVERALLS=1
-    - os: linux
-      python: "3.7"
-      dist: xenial
     - os: linux
       python: "3.8"
       dist: xenial
-    - os: linux
-      python: "3.9-dev"
-      dist: bionic
 
 install:
   - export PYVER=${TRAVIS_PYTHON_VERSION:0:1}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Travis build](https://travis-ci.org/G-Node/python-odml.svg?branch=master)](https://travis-ci.org/G-Node/python-odml)
+[![gh actions tests](https://github.com/G-Node/python-odml/workflows/run-tests/badge.svg?branch=master)](https://github.com/G-Node/python-odml/actions)
 [![Build status](https://ci.appveyor.com/api/projects/status/br7pe6atlwdg5618/branch/master?svg=true)](https://ci.appveyor.com/project/G-Node/python-odml/branch/master)
 [![Test coverage](https://coveralls.io/repos/github/G-Node/python-odml/badge.svg?branch=master)](https://coveralls.io/github/G-Node/python-odml)
 [![PyPI version](https://img.shields.io/pypi/v/odml.svg)](https://pypi.org/project/odML/)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+pytest
+owlrl
+requests

--- a/setup.py
+++ b/setup.py
@@ -30,9 +30,11 @@ packages = [
 with open('README.md') as f:
     description_text = f.read()
 
-install_req = ["lxml", "pyyaml>=5.1", "rdflib", "docopt", "pathlib"]
+# pyparsing needs to be pinned to 2.4.7 for the time being. setup install fetches a pre-release
+# package that currently results in issues with the rdflib library.
+install_req = ["lxml", "pyyaml>=5.1", "rdflib", "docopt", "pathlib", "pyparsing==2.4.7"]
 
-tests_req = ["owlrl", "requests"]
+tests_req = ["pytest", "owlrl", "requests"]
 
 if sys.version_info < (3, 4):
     install_req += ["enum34"]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import json
 import os
-import sys
 
 try:
     from setuptools import setup
@@ -35,9 +34,6 @@ with open('README.md') as f:
 install_req = ["lxml", "pyyaml>=5.1", "rdflib", "docopt", "pathlib", "pyparsing==2.4.7"]
 
 tests_req = ["pytest", "owlrl", "requests"]
-
-if sys.version_info < (3, 4):
-    install_req += ["enum34"]
 
 setup(
     name='odML',


### PR DESCRIPTION
Travis still accepts jobs, but it is slow and its unsure how long it will be available. Therefore we are migrating to github actions.

The current github actions setup
- runs all available tests in a `[ubuntu, macos, windows]`, Python `[3.6, 3.7, 3.8, 3.9]` matrix.
- runs coveralls separately using Python 3.8.

The PR also 
- fixes a dependency build issue: when installing the package using `python setup.py install` an unstable dependency, a pre-releae of `pyparsing` is installed by default. Setup.py now specifies the latest stable version. This fixes issue #410.
- adds a test requirements file for easy github actions installation.
- switches running tests from the deprecated `python setup.py test` to `pytest`.
- removes Python < 3.4 specific code from `setup.py` which we no longer support.
- reduces the travis setup to a single Linux build for the time being.
- switches the README travis badge with github actions.
