### PR TITLE
Pin RDFlib library, release 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,20 @@
 Used to document all changes from previous releases and collect changes 
 until the next release.
 
-# Latest
 
-# Dropping Python 2 support
+# Version 1.5.2
+
+## Pinning rdflib version to 5.0.0 until further notice
+
+Due to major breaking changes introduced in the upgrade of
+rdflib 5.0.0 to 6.0.0, the rdflib version is pinned to 5.0.0
+until the breaking code has been fixed.
+
+## Dropping Python 2 support
 
 Python 2 has reached end of life. The codebase has been cleaned from Python 2 and Python 3 compatible code, all tests now run exclusively on Python 3 versions.
 
-# Features
+## Features
 - `odml.save` and `odmlparser.ODMLWriter` now support additional keywords. See issue #402 and PR #403 for details.
 
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2018, German Neuroinformatics Node (G-Node)
+Copyright (c) 2011-2021, German Neuroinformatics Node (G-Node)
 
 All rights reserved.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,10 @@ environment:
     - PYTHON: "C:\\Python38"
       PYVER: 3
       BITS: 32
+    - PYTHON: "C:\\Python39"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      PYVER: 3
+      BITS: 32
     - PYTHON: "C:\\Python36-x64"
       PYVER: 3
       BITS: 64
@@ -20,6 +24,10 @@ environment:
       PYVER: 3
       BITS: 64
     - PYTHON: "C:\\Python38-x64"
+      PYVER: 3
+      BITS: 64
+    - PYTHON: "C:\\Python39-x64"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       PYVER: 3
       BITS: 64
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,4 +45,7 @@ install:
 
 test_script:
   - python --version
-  - python -m pytest -v
+  - python -m pytest -v -k "not handle_include and not handle_repository"
+# appveyor issues with SSL certificates; deactivating the affected tests,
+# since they run fine on GH actions Windows builds.
+# - python -m pytest -v

--- a/odml/__init__.py
+++ b/odml/__init__.py
@@ -30,7 +30,8 @@ def _format_warning(warn_msg, *args, **kwargs):
 warnings.formatwarning = _format_warning
 
 if _python_version.major < 3:
-    msg = "Python 2 has been deprecated.\n\todML support for Python 2 will be dropped August 2020."
+    msg = "Python 2 has reached end of live."
+    msg += "\n\todML support for Python 2 has been dropped."
     warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
 elif _python_version.major == 3 and _python_version.minor < 6:
     msg = "The '%s' package is not tested with your Python version. " % __name__

--- a/odml/info.json
+++ b/odml/info.json
@@ -11,6 +11,7 @@
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Topic :: Scientific/Engineering",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: BSD License"

--- a/odml/info.json
+++ b/odml/info.json
@@ -1,8 +1,8 @@
 {
-  "VERSION": "1.5.1",
+  "VERSION": "1.5.2",
   "FORMAT_VERSION": "1.1",
   "AUTHOR": "Hagen Fritsch, Jan Grewe, Christian Kellner, Achilleas Koutsou, Michael Sonntag, Lyuba Zehl",
-  "COPYRIGHT": "(c) 2011-2020, German Neuroinformatics Node",
+  "COPYRIGHT": "(c) 2011-2021, German Neuroinformatics Node",
   "CONTACT": "dev@g-node.org",
   "HOMEPAGE": "https://github.com/G-Node/python-odml",
   "CLASSIFIERS": [

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,3 @@
 pytest
-owlrl
+owlrl==5.2.3
 requests

--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,11 @@ with open('README.md') as f:
 
 # pyparsing needs to be pinned to 2.4.7 for the time being. setup install fetches a pre-release
 # package that currently results in issues with the rdflib library.
-install_req = ["lxml", "pyyaml>=5.1", "rdflib", "docopt", "pathlib", "pyparsing==2.4.7"]
+install_req = ["lxml", "pyyaml>=5.1", "rdflib==5.0.0", "docopt", "pathlib", "pyparsing==2.4.7"]
 
-tests_req = ["pytest", "owlrl", "requests"]
+# owlrl depends on rdflib - the pinned version should be removed once the version pin has also been
+# removed from rdflib.
+tests_req = ["pytest", "owlrl==5.2.3", "requests"]
 
 setup(
     name='odML',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 import json
 import os
 
+from sys import version_info as _python_version
+
 try:
     from setuptools import setup
 except ImportError as ex:
@@ -34,7 +36,7 @@ with open('README.md') as f:
 install_req = ["lxml", "pyyaml>=5.1", "rdflib==5.0.0", "docopt", "pathlib", "pyparsing==2.4.7"]
 
 # owlrl depends on rdflib - the pinned version should be removed once the version pin has also been
-# removed from rdflib.
+# removed from rdflib. Also needs to be updated in requirements-test.txt
 tests_req = ["pytest", "owlrl==5.2.3", "requests"]
 
 setup(
@@ -58,3 +60,13 @@ setup(
                                       'odmlconvert=odml.scripts.odml_convert:main',
                                       'odmlview=odml.scripts.odml_view:main']}
 )
+
+# Make this the last thing people read after a setup.py install
+if _python_version.major < 3:
+    msg = "\n\nPython 2 has been deprecated.\n"
+    msg += "\todML support for Python 2 will be dropped August 2020."
+    print(msg)
+elif _python_version.major == 3 and _python_version.minor < 6:
+    msg = "\n\nThis package is not tested with your Python version. "
+    msg += "\n\tPlease consider upgrading to the latest Python distribution."
+    print(msg)

--- a/setup.py
+++ b/setup.py
@@ -63,8 +63,8 @@ setup(
 
 # Make this the last thing people read after a setup.py install
 if _python_version.major < 3:
-    msg = "\n\nPython 2 has been deprecated.\n"
-    msg += "\todML support for Python 2 will be dropped August 2020."
+    msg = "Python 2 has reached end of live."
+    msg += "\n\todML support for Python 2 has been dropped."
     print(msg)
 elif _python_version.major == 3 and _python_version.minor < 6:
     msg = "\n\nThis package is not tested with your Python version. "


### PR DESCRIPTION
This PR
- pins the RDFlib library version and the test dependent owlrl library version. This is required since major changes were introduced to RDFlib in the 5.0.0->6.0.0 release. Until these breaking changes have been fixed in code, the libraries are pinned to ensure that a pip install of odml does not lead to broken code in the rdf specific parts of the odml library.
- adds a py2.7 and py3.5 deprecation warning to the `setup.py`.
- prepares the library for release 1.5.2: updates in info.json, CHANGELOG and LICENSE.
- adds Python 3.9 to appveyor
- deactivates two tests for appveyor builds only: The tests `test_handle_include` and `test_handle_repository` from the `TestVersionConverter` class consistently fail with an SSL certification failure on the appveyor Windows builds. Upgrading the `certifi` package does not resolve this issue. Since these tests run fine on Linux, Mac and on the GH actions
Windows builds, these tests are deactivated for Appveyor builds.