### PR TITLE
Remove shebang from modules

### DIFF
--- a/odml/tools/odmlparser.py
+++ b/odml/tools/odmlparser.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 A generic odML parsing module. It parses odML files and documents.
 All supported formats can be found in parser_utils.SUPPORTED_PARSERS.

--- a/odml/tools/xmlparser.py
+++ b/odml/tools/xmlparser.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 The xmlparser module provides access to the XMLWriter and XMLReader classes.
 Both handle the conversion of odML documents from and to XML files and strings.


### PR DESCRIPTION
Since these are not standalone scripts, but modules, they do not
require a shebang.

While packaging for Fedora rpmlint threw an error pointing this
out.
