### PR TITLE
Remove pathlib from requirements

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,7 +24,7 @@ jobs:
         run: python -c "import sys; print(sys.version)"
       - name: Install dependencies
         run: |
-          python setup.py install
+          pip install . install
           pip install -r requirements-test.txt
       - name: Run tests
         run: pytest
@@ -46,7 +46,7 @@ jobs:
         run: python -c "import sys; print(sys.version)"
       - name: Install dependencies
         run: |
-          python setup.py install
+          pip install . install
           pip install -r requirements-test.txt
       - name: Run tests
         run: pytest
@@ -72,7 +72,7 @@ jobs:
         run: python -c "import sys; print(sys.version)"
       - name: Install dependencies
         run: |
-          python setup.py install
+          pip install .
           pip install -r requirements-test.txt
       - name: Run tests
         run: pytest
@@ -98,7 +98,7 @@ jobs:
         run: python -c "import sys; print(sys.version)"
       - name: Install dependencies
         run: |
-          python setup.py install
+          pip install .
           pip install -r requirements-test.txt
       - name: Run tests
         run: pytest
@@ -114,7 +114,7 @@ jobs:
         run: python -c "import sys; print(sys.version)"
       - name: Install dependencies
         run: |
-          python setup.py install
+          pip install .
           pip install -r requirements-test.txt
           pip install pytest coveralls
       - name: Create coverage
@@ -134,7 +134,7 @@ jobs:
           python-version: "3.10"
       - name: Install dependencies
         run: |
-          python setup.py install
+          pip install .
           pip install -r requirements-test.txt
           pip install pytest pytest-cov
       - name: Create coverage

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ packages = [
 with open('README.md') as f:
     description_text = f.read()
 
-install_req = ["docopt", "lxml", "pathlib", "pyyaml>=5.1", "rdflib>=6.0.0"]
+install_req = ["docopt", "lxml", "pyyaml>=5.1", "rdflib>=6.0.0"]
 # owlrl depends on rdflib; update any changes in requirements-test.txt as well.
 tests_req = ["owlrl", "pytest", "requests"]
 
@@ -39,7 +39,7 @@ tests_req = ["owlrl", "pytest", "requests"]
 # rdflib usage; rdflib >= 6 does not support Python versions below 3.7.
 if _python_version.minor <= 6:
     # pyparsing needs to be pinned to 2.4.7 due to issues with the rdflib 5.0.0 library.
-    install_req = ["docopt", "lxml", "pathlib", "pyyaml>=5.1", "rdflib==5.0.0", "pyparsing==2.4.7"]
+    install_req = ["docopt", "lxml", "pyyaml>=5.1", "rdflib==5.0.0", "pyparsing==2.4.7"]
 
     # owlrl depends on rdflib and needs to be pinned to a corresponding version.
     tests_req = ["owlrl==5.2.3", "pytest", "requests"]


### PR DESCRIPTION
Currently `setup.py` requires `pathlib`, which leads pip to install the outdated and no longer maintained [pathlib package](https://pypi.org/project/pathlib/) which is not compatible with Python 3.10 or later (`collections.Sequence` is now `collections.abc.Sequence`).

Since `pathlib` has been part of the standard Python library since Python 3.4, it is not necessary to install it, as it is there by default. Therefore, this PR removes `pathlib` from the list of requirements.

I'd appreciate a quick merge and release on PyPi, since this problem breaks things so badly that you cannot even deactivate your conda enviroment after pip-installing python-odml.